### PR TITLE
[Init] 예/적금 추천 관련 초기 컴포넌트 구조 생성

### DIFF
--- a/src/components/bankbook/BankbookProductCard.vue
+++ b/src/components/bankbook/BankbookProductCard.vue
@@ -1,0 +1,140 @@
+<template>
+  <div class="product-card">
+    <div class="product-card__header">
+      <div>
+        <div class="product-card__company">{{ saving.company }}</div>
+        <div class="product-card__title">{{ saving.title }}</div>
+      </div>
+      <FavoriteToggle v-model="saving.is_starred" />
+    </div>
+
+    <div class="product-card__body" @click="onClick">
+      <div class="product-card__logo-box">
+        <img
+          :src="saving.company_logo_url"
+          alt="logo"
+          class="product-card__logo"
+        />
+        <CompareButton @click="onCompareClick" />
+      </div>
+
+      <div class="product-card__info">
+        <div class="product-card__row">
+          <span>최고 금리</span>
+          <span class="product-card__highlight">{{ saving.max_rate }}</span>
+        </div>
+        <div class="product-card__row">
+          <span>기본 금리</span>
+          <span>{{ saving.base_rate }}</span>
+        </div>
+        <div class="product-card__row">
+          <span>금액</span>
+          <span>{{ saving.amount }}</span>
+        </div>
+        <div class="product-card__row">
+          <span>개월 수</span>
+          <span>{{ saving.period }}</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { defineProps } from 'vue';
+import FavoriteToggle from '@/components/common/FavoriteToggle.vue';
+import CompareButton from '@/components/common/CompareButton.vue';
+const props = defineProps({
+  saving: {
+    type: Object,
+    required: true,
+  },
+});
+const onCompareClick = () => {
+  console.log(`${props.saving.id} 비교 추가 클릭됨`);
+  // 향후 비교목록에 저장하는 로직 추가 가능
+};
+
+const onClick = () => {
+  console.log(`${props.saving.id} 상세보러 가자!!`);
+  // 향후 비교목록에 저장하는 로직 추가 가능
+};
+</script>
+
+<style scoped>
+.product-card {
+  width: 100%;
+  background-color: var(--color-light);
+  box-shadow: var(--shadow-xl);
+  border-radius: var(--spacing-md);
+  box-shadow: var(--shadow-card);
+  padding: var(--spacing-md) var(--spacing-md);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+}
+
+.product-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.product-card__company {
+  font-size: var(--font-size-base);
+  color: var(--color-gray-400);
+  font-weight: bold;
+}
+
+.product-card__title {
+  font-size: var(--font-size-2xl);
+  color: var(--color-title);
+  font-weight: bold;
+}
+
+.product-card__body {
+  display: flex;
+  gap: 5%;
+}
+
+.product-card__logo-box {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--spacing-xs);
+  width: 28%;
+  height: 100%;
+  text-align: center;
+}
+
+.product-card__logo {
+  width: 100%;
+  object-fit: contain;
+  border-radius: 50%;
+  margin: auto;
+}
+
+.product-card__info {
+  width: 68%;
+  display: grid;
+  align-items: center;
+  grid-template-columns:
+    1fr
+    2fr;
+  gap: var(--spacing-xs);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  color: var(--color-gray-500);
+}
+
+.product-card__row {
+  display: contents; /* 자식 span이 직접 grid 셀 차지하도록 */
+}
+
+.product-card__highlight {
+  font-size: var(--font-size-base);
+  color: var(--color-accent);
+  font-weight: bold;
+}
+</style>

--- a/src/components/bankbook/BankbookProductList.vue
+++ b/src/components/bankbook/BankbookProductList.vue
@@ -1,0 +1,153 @@
+<template>
+  <div class="product-list">
+    <BankbookProductCard
+      v-for="(saving, index) in filteredSavings"
+      :key="index"
+      :saving="saving"
+    />
+  </div>
+</template>
+<style scoped>
+.product-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-lg);
+}
+
+.product-card {
+  flex: 1 1 calc(50% - var(--font-size-xs)); /* 2개씩 */
+  max-width: calc(50% - var(--font-size-xs));
+}
+
+@media (max-width: 1280px) {
+  .product-card {
+    flex: 1 1 100%;
+    max-width: 100%;
+  }
+}
+</style>
+<script setup>
+import { ref, computed, defineProps } from 'vue';
+import BankbookProductCard from './BankbookProductCard.vue';
+
+const props = defineProps({
+  selectedId: String,
+});
+
+const filteredSavings = computed(() =>
+  props.selectedId
+    ? savings.value.filter((s) => s.id === props.selectedId)
+    : savings.value
+);
+
+const savings = ref([
+  {
+    id: 'kb001',
+    company: 'KB국민은행',
+    title: '여행자유적금',
+    max_rate: '연 3.80 %',
+    base_rate: '연 2.40 %',
+    amount: '월 10만원 ~ 200만원',
+    period: '12개월',
+    company_logo_url:
+      'https://www.gcsw.co.kr/theme/basic/images/sub/spo_bank2.png',
+    is_starred: true,
+  },
+  {
+    id: 'shinhan002',
+    company: '신한은행',
+    title: '쏠스마트적금',
+    max_rate: '연 3.10 %',
+    base_rate: '연 2.00 %',
+    amount: '월 3만원 ~ 70만원',
+    period: '24개월',
+    company_logo_url:
+      'https://www.gcsw.co.kr/theme/basic/images/sub/spo_bank2.png',
+    is_starred: false,
+  },
+  {
+    id: 'kb001',
+    company: 'KB국민은행',
+    title: 'KB하이플랜적금',
+    max_rate: '연 4.00 %',
+    base_rate: '연 2.75 %',
+    amount: '월 5만원 ~ 150만원',
+    period: '06개월',
+    company_logo_url:
+      'https://www.gcsw.co.kr/theme/basic/images/sub/spo_bank2.png',
+    is_starred: false,
+  },
+  {
+    id: 'shinhan002',
+    company: '신한은행',
+    title: '신한청년희망적금',
+    max_rate: '연 3.45 %',
+    base_rate: '연 2.30 %',
+    amount: '월 1만원 ~ 100만원',
+    period: '18개월',
+    company_logo_url:
+      'https://www.gcsw.co.kr/theme/basic/images/sub/spo_bank2.png',
+    is_starred: true,
+  },
+  {
+    id: 'kb001',
+    company: 'KB국민은행',
+    title: 'KB자유정기적금',
+    max_rate: '연 3.55 %',
+    base_rate: '연 2.55 %',
+    amount: '월 2만원 ~ 120만원',
+    period: '36개월',
+    company_logo_url:
+      'https://www.gcsw.co.kr/theme/basic/images/sub/spo_bank2.png',
+    is_starred: true,
+  },
+  {
+    id: 'shinhan002',
+    company: '신한은행',
+    title: '신한꿈나무적금',
+    max_rate: '연 3.90 %',
+    base_rate: '연 2.80 %',
+    amount: '월 2만원 ~ 60만원',
+    period: '06개월',
+    company_logo_url:
+      'https://www.gcsw.co.kr/theme/basic/images/sub/spo_bank2.png',
+    is_starred: false,
+  },
+  {
+    id: 'hana003',
+    company: '하나은행',
+    title: '하나군적금',
+    max_rate: '연 4.10 %',
+    base_rate: '연 2.85 %',
+    amount: '월 5만원 ~ 80만원',
+    period: '18개월',
+    company_logo_url:
+      'https://www.gcsw.co.kr/theme/basic/images/sub/spo_bank2.png',
+    is_starred: true,
+  },
+  {
+    id: 'hana003',
+    company: '하나은행',
+    title: '하나스마트적금',
+    max_rate: '연 3.60 %',
+    base_rate: '연 2.40 %',
+    amount: '월 1만원 ~ 100만원',
+    period: '24개월',
+    company_logo_url:
+      'https://www.gcsw.co.kr/theme/basic/images/sub/spo_bank2.png',
+    is_starred: false,
+  },
+  {
+    id: 'hana003',
+    company: '하나은행',
+    title: '하나하이적금',
+    max_rate: '연 3.20 %',
+    base_rate: '연 1.90 %',
+    amount: '월 3만원 ~ 90만원',
+    period: '12개월',
+    company_logo_url:
+      'https://www.gcsw.co.kr/theme/basic/images/sub/spo_bank2.png',
+    is_starred: false,
+  },
+]);
+</script>

--- a/src/components/common/CompareButton.vue
+++ b/src/components/common/CompareButton.vue
@@ -1,0 +1,28 @@
+<!-- src/components/base/CompareButton.vue -->
+<template>
+  <div class="compare-button" @click.stop="$emit('click')">⊕ {{ label }}</div>
+</template>
+
+<script setup>
+defineProps({
+  label: {
+    type: String,
+    default: '비교 추가',
+  },
+});
+defineEmits(['click']);
+</script>
+
+<style scoped>
+.compare-button {
+  font-size: var(--font-size-sm);
+  color: var(--color-accent);
+  font-weight: bold;
+  cursor: pointer;
+  text-align: center;
+  transition: transform 0.2s ease;
+}
+.compare-button:hover {
+  transform: scale(1.05);
+}
+</style>

--- a/src/components/common/FavoriteToggle.vue
+++ b/src/components/common/FavoriteToggle.vue
@@ -1,0 +1,48 @@
+<template>
+  <i
+    :class="[isActive ? 'fas fa-star' : 'far fa-star', 'favorite-icon']"
+    @click="toggle"
+    title="즐겨찾기"
+  ></i>
+</template>
+
+<script setup>
+import { ref, watch, defineProps, defineEmits } from 'vue';
+
+const props = defineProps({
+  modelValue: {
+    type: Boolean,
+    required: true,
+  },
+});
+
+const emit = defineEmits(['update:modelValue']);
+
+const isActive = ref(props.modelValue);
+
+watch(
+  () => props.modelValue,
+  (val) => {
+    isActive.value = val;
+  }
+);
+
+const toggle = () => {
+  isActive.value = !isActive.value;
+  console.log('즐겨찾기 변경');
+  emit('update:modelValue', isActive.value);
+};
+</script>
+
+<style scoped>
+.favorite-icon {
+  color: #ffbb00;
+  font-size: var(--font-size-3xl);
+  cursor: pointer;
+  transition: transform 0.25s cubic-bezier(0.33, 1, 0.68, 1);
+}
+
+.favorite-icon:hover {
+  transform: scale(1.2);
+}
+</style>

--- a/src/components/common/TabSelector.vue
+++ b/src/components/common/TabSelector.vue
@@ -1,0 +1,67 @@
+<template>
+  <div class="tab-container">
+    <div
+      v-for="tab in tabs"
+      :key="tab"
+      :class="['tab-item', { active: selectedTab === tab }]"
+      @click="selectTab(tab)"
+    >
+      {{ tab }}
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'TabSelector',
+  data() {
+    return {
+      tabs: ['예금', '적금', '카드'],
+      selectedTab: tabs[0],
+    };
+  },
+  methods: {
+    selectTab(tab) {
+      this.selectedTab = tab;
+      this.$emit('change-tab', tab); // 부모에 알릴 수 있음
+    },
+  },
+};
+</script>
+
+<style scoped>
+.tab-container {
+  display: flex;
+  background-color: var(--color-accent); /* 전체 배경 */
+  border-radius: 2rem;
+  padding: clamp(4px, 1%, 6px);
+}
+
+.tab-item {
+  transition: 0.3s ease-in-out;
+  flex: 1;
+  text-align: center;
+  padding: 2% 0;
+  padding: clamp(4px, 2%, 12px) 0;
+  border-radius: 2rem;
+  color: var(--color-white);
+  cursor: pointer;
+  transition: 0.2s;
+  font-size: 1.2rem;
+  font-weight: 900;
+}
+
+.tab-item.active {
+  background-color: var(--color-white);
+  color: var(--color-accent); /* 전체 배경 */
+}
+
+.tab-item:hover {
+  background-color: var(--color-dark);
+}
+
+.tab-item.active:hover {
+  background-color: var(--color-white);
+  color: var(--color-accent);
+}
+</style>

--- a/src/components/layouts/RecommendationLayout.vue
+++ b/src/components/layouts/RecommendationLayout.vue
@@ -1,0 +1,48 @@
+<template>
+  <div class="recommendation-layout">
+    <h2 class="section-title text-center">{{ title }}</h2>
+
+    <!-- 슬라이더 영역 -->
+    <div class="recommendation-slider">
+      <slot name="slider" />
+    </div>
+
+    <!-- 강조 문구 영역 -->
+    <div class="recommendation-highlight text-center mt-5">
+      <slot name="highlight" />
+    </div>
+
+    <!-- 본문 리스트 영역 -->
+    <div class="recommendation-content">
+      <slot name="content" />
+    </div>
+  </div>
+</template>
+
+<script setup>
+const props = defineProps({
+  title: {
+    type: String,
+    required: true,
+  },
+});
+</script>
+
+<style scoped>
+.section-title {
+  font-size: var(--font-size-xl);
+  font-weight: bold;
+  margin: 0 0 var(--spacing-md) 0;
+  color: var(--color-title);
+}
+.recommendation-slider,
+.recommendation-highlight,
+.recommendation-content {
+  font-size: var(--font-size-base);
+  margin: var(--spacing-md) 0;
+}
+.recommendation-highlight {
+  color: var(--color-accent);
+  font-weight: bold;
+}
+</style>

--- a/src/components/savings/SavingMyProductCard.vue
+++ b/src/components/savings/SavingMyProductCard.vue
@@ -1,0 +1,107 @@
+<script setup>
+defineProps({
+  saving: {
+    type: Object,
+    required: true,
+    default: () => ({
+      title: '',
+      startDate: '',
+      endDate: '',
+      rate: '',
+      logoUrl: 'https://www.gcsw.co.kr/theme/basic/images/sub/spo_bank2.png',
+    }),
+  },
+});
+</script>
+
+<template>
+  <div class="saving-card">
+    <!-- <img :src="saving.logoUrl" alt="company" class="product-logo" /> -->
+    <div class="card-content">
+      <div class="card-title">{{ saving.title }}</div>
+      <div class="card-info">
+        <div class="date-section">
+          <div class="info-row">
+            <div class="label">신규일</div>
+            <div class="value">{{ saving.start_date }}</div>
+          </div>
+          <div class="info-row">
+            <div class="label">만기일</div>
+            <div class="value">{{ saving.end_date }}</div>
+          </div>
+        </div>
+        <div class="rate-section">
+          <div class="label">금리</div>
+          <div class="rate">{{ saving.rate }}</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.saving-card {
+  background-color: var(--color-primary);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: var(--spacing-lg) var(--spacing-xl);
+  border-radius: var(--spacing-lg);
+  gap: var(--spacing-md);
+  box-shadow: var(--shadow-card);
+}
+
+.product-logo {
+  width: 24%;
+  max-width: 200px;
+}
+
+.card-content {
+  width: clamp(250px, 100%, 8000px);
+}
+
+.card-title {
+  font-weight: bold;
+  font-size: var(--font-size-2xl);
+  color: var(--color-dark);
+  margin-bottom: var(--spacing-md);
+}
+
+.card-info {
+  display: flex;
+  justify-content: space-between;
+  align-items: end;
+  font-size: var(--font-size-base);
+  color: var(--color-title);
+}
+
+.date-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.rate-section {
+  display: flex;
+  align-items: end;
+  gap: var(--spacing-sm);
+}
+
+.info-row {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--spacing-sm);
+}
+
+.value,
+.label {
+  color: var(--color-title);
+  font-weight: bold;
+}
+
+.rate {
+  color: var(--color-accent);
+  font-weight: bold;
+  font-size: var(--font-size-xl);
+}
+</style>

--- a/src/components/savings/SavingMyProductSlider.vue
+++ b/src/components/savings/SavingMyProductSlider.vue
@@ -1,0 +1,70 @@
+<template>
+  <swiper
+    :slides-per-view="1"
+    :space-between="16"
+    :loop="false"
+    class="saving-swiper"
+    @slideChange="onSlideChange"
+    ref="swiperRef"
+  >
+    <swiper-slide v-for="(item, index) in savingList" :key="index">
+      <SavingMyProductCard :saving="item" />
+    </swiper-slide>
+  </swiper>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue';
+import { Swiper, SwiperSlide } from 'swiper/vue';
+import 'swiper/css';
+
+import SavingMyProductCard from './SavingMyProductCard.vue';
+
+const emit = defineEmits(['select']);
+const swiperRef = ref(null);
+
+// 예시 데이터
+const savingList = [
+  {
+    id: 'kb001',
+    title: 'KB두근두근여행적금',
+    start_date: '2025.03.06',
+    end_date: '2025.09.06',
+    rate: '3.6%',
+  },
+  {
+    id: 'shinhan002',
+    title: '청년도약계좌',
+    start_date: '2025.01.01',
+    end_date: '2030.01.01',
+    rate: '4.2%',
+  },
+  {
+    id: 'hana003',
+    title: '하나장병적금',
+    startDate: '2024.11.20',
+    endDate: '2026.11.20',
+    rate: '5.0%',
+  },
+];
+
+// 슬라이드 변경 시 현재 index로 emit
+const onSlideChange = (swiper) => {
+  const currentIndex = swiper.activeIndex;
+  const selected = savingList[currentIndex];
+  // console.log('슬라이드 값 변경' + selected.id);
+  if (selected) emit('select', selected.id);
+};
+
+// 최초 첫 번째 상품 emit
+onMounted(() => {
+  emit('select', savingList[0].id);
+});
+</script>
+
+<style scoped>
+.saving-swiper {
+  border-radius: var(--spacing-md);
+  box-shadow: var(--shadow-card);
+}
+</style>

--- a/src/pages/savings/recommendations/History.vue
+++ b/src/pages/savings/recommendations/History.vue
@@ -1,0 +1,22 @@
+<script setup>
+import { ref } from 'vue';
+import SavingMyProductSlider from '@/components/savings/SavingMyProductSlider.vue';
+import BankbookProductList from '@/components/bankbook/BankbookProductList.vue';
+import RecommendationLayout from '@/components/layouts/RecommendationLayout.vue';
+// ✅ 이 부분 추가!
+const selectedId = ref(null);
+</script>
+
+<template>
+  <RecommendationLayout title="적금 추천">
+    <template #slider>
+      <SavingMyProductSlider @select="(id) => (selectedId = id)" />
+    </template>
+
+    <template #highlight> 지금보다 더 좋은 적금 상품을 찾았어요! </template>
+
+    <template #content>
+      <BankbookProductList :selectedId="selectedId" />
+    </template>
+  </RecommendationLayout>
+</template>


### PR DESCRIPTION
🛠 작업 내용
예/적금 추천 관련 UI 컴포넌트 초기 구조화

다음과 같은 컴포넌트들을 생성하였습니다:
* 예/적금 상품 Card 및 CardList 컴포넌트 생성
* 사용자 보유 적금 상품 Card 및 Slider 컴포넌트 생성
* 보유 적금 기반 추천 페이지 초기 레이아웃 구성
* 비교 추가 버튼 및 즐겨찾기(⭐) 버튼 컴포넌트 추가
* 예/적금, 카드 탭 선택용 TabSelector 컴포넌트 생성

📎 관련 이슈
#2 

📸 스크린샷
<img width="362" height="801" alt="image" src="https://github.com/user-attachments/assets/dd487aa0-d16e-43f4-8cb4-128499aecf18" />


✅ 참고 사항
* UI 구성 요소 중심으로 초기 세팅된 상태이며, 실제 API 연동 및 데이터 바인딩은 추후 진행 예정입니다.
* 추후 스타일 개선 및 공통 컴포넌트 분리는 논의 후 진행할 예정입니다.