### PR TITLE
 [Fix] 로딩창이 150ms 지연되어 뜨도록 수정

### DIFF
--- a/src/components/common/Loading.vue
+++ b/src/components/common/Loading.vue
@@ -1,15 +1,34 @@
 <template>
-  <div class="loading-overlay">
-    <img src="../../assets/loading/loading_character.gif" style="width: 8rem" />
+  <div v-if="shouldShow" class="loading-overlay">
+    <img src="@/assets/loading/loading_character.gif" style="width: 8rem" />
   </div>
 </template>
+
 <script setup>
-import { defineProps } from 'vue';
+import { defineProps, ref, watch } from 'vue';
 
 const props = defineProps({
   loading: Boolean,
 });
+
+const shouldShow = ref(false);
+let timeoutId = null;
+
+watch(
+  () => props.loading,
+  (newVal) => {
+    clearTimeout(timeoutId);
+    if (newVal) {
+      timeoutId = setTimeout(() => {
+        shouldShow.value = true;
+      }, 150); // 100ms 지연
+    } else {
+      shouldShow.value = false;
+    }
+  }
+);
 </script>
+
 <style scoped>
 .loading-overlay {
   position: absolute;


### PR DESCRIPTION
## 🔥 PR 제목 
- [Fix] 로딩창이 150ms 지연되어 뜨도록 수정

---

## 📎 관련 이슈
- Closes #34

---

## 🛠 작업 내용
- 로딩창이 바로 표시됨으로 인한 화면이 튀는 현상을 완화하기 위해 지연 시간을 두었습니다.
    - 로딩이 150ms이상인 경우에만 표시되도록 하였습니다.
        - 그 이하인 경우 표시되지 않도록 하여 화면이 튀는 듯한 현상을 완화하였습니다.

- 참고사항
    - 150ms 시간이 짧다보니 로딩이 지연되는 듯한 느낌을 저는 못받았습니다.
        - 만약 로딩창이 느리게 뜨는 것 같다면 이로 인한 것이므로 시간을 짧게 수정하시면 됩니다!
        - 해당 시간은 components/common/Loading.vue의 하단 코드의 150을 수정하면 변경이 가능합니다. 
        