### PR TITLE
[Feat] 즐겨찾기 컴포넌트 백엔드 연동 

### DIFF
--- a/src/api/favorite.js
+++ b/src/api/favorite.js
@@ -1,0 +1,14 @@
+import api from '@/api';
+
+const BASE_URL = `/favorite`;
+
+export default {
+  async addFavorite(productId, productType) {
+    const query = new URLSearchParams({ productType }).toString();
+    await api.post(`${BASE_URL}/${productId}?${query}`);
+  },
+  async deleteFavorite(productId, productType) {
+    const query = new URLSearchParams({ productType }).toString();
+    await api.delete(`${BASE_URL}/${productId}?${query}`);
+  },
+};

--- a/src/components/bankbook/BankbookProductCard.vue
+++ b/src/components/bankbook/BankbookProductCard.vue
@@ -5,7 +5,11 @@
         <div class="product-card__company">{{ saving.company }}</div>
         <div class="product-card__title">{{ saving.title }}</div>
       </div>
-      <FavoriteToggle v-model="saving.is_starred" />
+      <FavoriteToggle
+        v-model="saving.is_starred"
+        :productId="saving.id"
+        :productType="productType"
+      />
     </div>
 
     <div class="product-card__body" @click="onClick">
@@ -58,6 +62,9 @@ import { defineProps } from 'vue';
 import FavoriteToggle from '@/components/common/FavoriteToggle.vue';
 import CompareButton from '@/components/common/CompareButton.vue';
 import { roundToTwoDecimalPlaces } from '@/util/numberFormatter';
+import { ProductType } from '@/constants/productTypes';
+
+const productType = ProductType.SAVING;
 const props = defineProps({
   saving: {
     type: Object,

--- a/src/components/common/FavoriteToggle.vue
+++ b/src/components/common/FavoriteToggle.vue
@@ -8,10 +8,19 @@
 
 <script setup>
 import { computed, defineProps, defineEmits } from 'vue';
+import favorite from '@/api/favorite';
 
 const props = defineProps({
   modelValue: {
     type: Boolean, // "true" / "false" 문자열로 전달됨
+    required: true,
+  },
+  productId: {
+    type: String,
+    required: true,
+  },
+  productType: {
+    type: String,
     required: true,
   },
 });
@@ -23,9 +32,30 @@ const isActive = computed({
   set: (val) => emit('update:modelValue', val), // ✅ 올바른 setter
 });
 
-const toggle = () => {
-  isActive.value = !isActive.value;
-  console.log('즐겨찾기 변경:', isActive.value);
+const toggle = async () => {
+  if (isActive.value) {
+    try {
+      await favorite.deleteFavorite(props.productId, props.productType);
+      isActive.value = !isActive.value;
+      console.log(
+        props.productType + '의 ' + props.productId + ' 상품 즐겨찾기 제거'
+      );
+    } catch (e) {
+      console.log(e);
+    } finally {
+    }
+  } else {
+    try {
+      await favorite.addFavorite(props.productId, props.productType);
+      isActive.value = !isActive.value;
+      console.log(
+        props.productType + '의 ' + props.productId + ' 상품 즐겨찾기 추가'
+      );
+    } catch (e) {
+      console.log(e);
+    } finally {
+    }
+  }
 };
 </script>
 

--- a/src/constants/productTypes.js
+++ b/src/constants/productTypes.js
@@ -1,0 +1,5 @@
+export const ProductType = {
+  SAVING: 'SAVING',
+  LOAN: 'LOAN',
+  CARD: 'CARD',
+};


### PR DESCRIPTION
## 🔥 PR 제목
- [Feat] 즐겨찾기 컴포넌트 백엔드 연동 

---

## 📎 관련 이슈
- 관련 이슈: #46
---

## 🛠 작업 내용
- 즐겨찾기 추가/제거 백엔드 연동을 구현
    - props
      - modelValue = 즐겨찾기 여부
      - productId = 상품번호
      - productType = 상품 타입 (@/constants/productTypes 중 선택)
    - 즐겨찾기 여부가 제대로 연결되지 않으면 오류가 발생합니다. (이후 리팩토링 시 수정 예정)
    - 로딩창 이후 연결 예정(해당 부분 구현 후 branch 닫을 예정)
- 사용 방법
   - https://www.notion.so/240b0bacfffd802eb3ceea576469bd49 

- 형태
   - 즐겨찾기 X
      <img width="47" height="47" alt="image" src="https://github.com/user-attachments/assets/0a6caf51-da9f-4657-88d3-d4804fbd414d" />
   - 즐겨찾기 O
     <img width="43" height="38" alt="image" src="https://github.com/user-attachments/assets/e33fb48d-a54d-4b05-960d-4eb7e8de4605" />

안된다면 백엔드 favoriteController에 /api/ 추가해주세요!
