### PR TITLE
[Feat] 보유 카드 거래내역 기반 카드 추천

### DIFF
--- a/src/api/cards.js
+++ b/src/api/cards.js
@@ -66,7 +66,7 @@ export default {
   async getCardBenefits(cardId) {
     // console.log("💰 카드 혜택 조회 요청:", cardId);
     const { data } = await api.get(
-      `/v1/card-recommendation/cards/${cardId}/benefits`
+      `/card-recommendation/cards/${cardId}/benefits`
     );
     // console.log("✅ 카드 혜택 응답:", data);
     return data;
@@ -76,7 +76,7 @@ export default {
   async getCardRecommendations(cardId) {
     // console.log("🎯 카드 추천 조회 요청:", cardId);
     const { data } = await api.get(
-      `/v1/card-recommendation/cards/${cardId}/recommendations`
+      `/card-recommendation/cards/${cardId}/recommendations`
     );
     // console.log("✅ 카드 추천 응답:", data);
     return data;
@@ -85,7 +85,7 @@ export default {
   // 사용자 보유 카드 전체 혜택 조회
   async getMyCardsBenefits() {
     // console.log("📊 보유 카드 혜택 조회 요청");
-    const { data } = await api.get(`/v1/card-recommendation/my-cards/benefits`);
+    const { data } = await api.get(`/card-recommendation/my-cards/benefits`);
     // console.log("✅ 보유 카드 혜택 응답:", data);
     return data;
   },
@@ -94,7 +94,7 @@ export default {
   async getSavedRecommendations(cardId) {
     // console.log("💾 저장된 추천 조회 요청:", cardId);
     const { data } = await api.get(
-      `/v1/card-recommendation/cards/${cardId}/saved-recommendations`
+      `/card-recommendation/cards/${cardId}/saved-recommendations`
     );
     // console.log("✅ 저장된 추천 응답:", data);
     return data;
@@ -104,7 +104,7 @@ export default {
   async getAllSavedRecommendations() {
     // console.log("📋 모든 저장된 추천 조회 요청");
     const { data } = await api.get(
-      `/v1/card-recommendation/saved-recommendations`
+      `/card-recommendation/saved-recommendations`
     );
     // console.log("✅ 모든 저장된 추천 응답:", data);
     return data;
@@ -114,7 +114,7 @@ export default {
   async deleteSavedRecommendations(cardId) {
     // console.log("🗑️ 저장된 추천 삭제 요청:", cardId);
     const { data } = await api.delete(
-      `/v1/card-recommendation/cards/${cardId}/saved-recommendations`
+      `/card-recommendation/cards/${cardId}/saved-recommendations`
     );
     // console.log("✅ 저장된 추천 삭제 응답:", data);
     return data;

--- a/src/api/cards.js
+++ b/src/api/cards.js
@@ -1,6 +1,6 @@
 import api from "@/api";
 
-const BASE_URL = `users/me`;
+const BASE_URL = `/users/me`;
 
 export default {
   // 사용자 카드 정보 동기화 (KB카드 마이데이터 API 호출)
@@ -30,16 +30,93 @@ export default {
     return data;
   },
 
-  // 저장된 카드 거래 내역 조회
+  // 저장된 카드 거래 내역 조회 (holdingId 방식)
   async getStoredCardTransactions(holdingId, userId) {
-    // console.log("📋 저장된 거래내역 조회:", { holdingId, userId });
+    // console.log("📋 holdingId로 저장된 거래내역 조회:", { holdingId, userId });
     const { data } = await api.get(
       `${BASE_URL}/cards/${holdingId}/transactions`,
       {
         params: { userId },
       }
     );
-    // console.log("✅ 저장된 거래내역 응답:", data);
+    return data;
+  },
+
+  // 저장된 카드 거래 내역 조회 (finId 방식)
+  async getStoredCardTransactionsByFinId(finId, userId) {
+    // console.log("📋 finId로 저장된 거래내역 조회:", { finId, userId });
+    const { data } = await api.get(
+      `${BASE_URL}/cards/finId/${finId}/transactions`,
+      {
+        params: { userId },
+      }
+    );
+    return data;
+  },
+
+  // 디버그: 사용자의 모든 거래내역 상태 조회
+  async debugUserTransactions(userId) {
+    // console.log("🔍 디버그: 사용자 거래내역 상태 조회:", { userId });
+    const { data } = await api.get(`${BASE_URL}/debug/transactions/${userId}`);
+    return data;
+  },
+
+  // 카드 추천 관련 API
+  // 특정 카드 혜택 조회
+  async getCardBenefits(cardId) {
+    // console.log("💰 카드 혜택 조회 요청:", cardId);
+    const { data } = await api.get(
+      `/v1/card-recommendation/cards/${cardId}/benefits`
+    );
+    // console.log("✅ 카드 혜택 응답:", data);
+    return data;
+  },
+
+  // 더 나은 카드 추천 조회
+  async getCardRecommendations(cardId) {
+    // console.log("🎯 카드 추천 조회 요청:", cardId);
+    const { data } = await api.get(
+      `/v1/card-recommendation/cards/${cardId}/recommendations`
+    );
+    // console.log("✅ 카드 추천 응답:", data);
+    return data;
+  },
+
+  // 사용자 보유 카드 전체 혜택 조회
+  async getMyCardsBenefits() {
+    // console.log("📊 보유 카드 혜택 조회 요청");
+    const { data } = await api.get(`/v1/card-recommendation/my-cards/benefits`);
+    // console.log("✅ 보유 카드 혜택 응답:", data);
+    return data;
+  },
+
+  // 저장된 추천 카드 조회
+  async getSavedRecommendations(cardId) {
+    // console.log("💾 저장된 추천 조회 요청:", cardId);
+    const { data } = await api.get(
+      `/v1/card-recommendation/cards/${cardId}/saved-recommendations`
+    );
+    // console.log("✅ 저장된 추천 응답:", data);
+    return data;
+  },
+
+  // 모든 저장된 추천 카드 조회
+  async getAllSavedRecommendations() {
+    // console.log("📋 모든 저장된 추천 조회 요청");
+    const { data } = await api.get(
+      `/v1/card-recommendation/saved-recommendations`
+    );
+    // console.log("✅ 모든 저장된 추천 응답:", data);
+    return data;
+  },
+
+  // 저장된 추천 카드 삭제
+  async deleteSavedRecommendations(cardId) {
+    // console.log("🗑️ 저장된 추천 삭제 요청:", cardId);
+    const { data } = await api.delete(
+      `/v1/card-recommendation/cards/${cardId}/saved-recommendations`
+    );
+    // console.log("✅ 저장된 추천 삭제 응답:", data);
     return data;
   },
 };

--- a/src/components/cards/CardRecommendationSection.vue
+++ b/src/components/cards/CardRecommendationSection.vue
@@ -1,0 +1,704 @@
+<template>
+  <div class="card-recommendation-section">
+    <div class="section-header">
+      <h3>
+        <i class="bi bi-stars"></i>
+        {{ selectedCard?.cardName || "카드" }} 맞춤 추천
+      </h3>
+      <p class="section-subtitle">
+        소비 패턴을 분석하여 더 나은 카드를 추천해드립니다
+      </p>
+    </div>
+
+    <!-- 로딩 상태 -->
+    <div v-if="loading" class="loading-state">
+      <BaseSpinner size="md" />
+      <p>추천 카드를 분석하고 있습니다...</p>
+    </div>
+
+    <!-- 오류 상태 -->
+    <div v-else-if="error" class="error-state">
+      <div class="error-icon">⚠️</div>
+      <p class="error-message">{{ error }}</p>
+      <BaseButton @click="loadRecommendations" variant="outline" size="sm">
+        다시 시도
+      </BaseButton>
+    </div>
+
+    <!-- 추천 결과 없음 -->
+    <div
+      v-else-if="
+        recommendationData && recommendationData.recommendedCards.length === 0
+      "
+      class="no-recommendations"
+    >
+      <div class="empty-icon">✅</div>
+      <h4>현재 카드가 최적입니다</h4>
+      <p>
+        {{
+          recommendationData.message ||
+          "현재 사용 중인 카드가 소비 패턴에 가장 적합합니다."
+        }}
+      </p>
+    </div>
+
+    <!-- 추천 카드 목록 -->
+    <div
+      v-else-if="
+        recommendationData && recommendationData.recommendedCards.length > 0
+      "
+      class="recommendations-content"
+    >
+      <!-- 혜택 비교 요약 -->
+      <div class="benefit-summary">
+        <div class="current-benefit">
+          <span class="label">현재 예상 혜택</span>
+          <span class="amount"
+            >{{ formatCurrency(getCurrentBenefit()) }}원</span
+          >
+        </div>
+        <div class="arrow">→</div>
+        <div class="recommended-benefit">
+          <span class="label">최대 예상 혜택</span>
+          <span class="amount highlight"
+            >{{
+              formatCurrency(
+                recommendationData.recommendedCards[0]?.estimatedBenefit
+              )
+            }}원</span
+          >
+        </div>
+        <div class="improvement">
+          <span class="improvement-label">개선 효과</span>
+          <span class="improvement-amount"
+            >+{{ formatCurrency(getBenefitImprovement()) }}원</span
+          >
+        </div>
+      </div>
+
+      <!-- 추천 카드 리스트 -->
+      <div class="recommendations-list">
+        <div
+          v-for="(card, index) in recommendationData.recommendedCards.slice(
+            0,
+            3
+          )"
+          :key="card.cardId"
+          class="recommendation-item"
+          :class="{ 'top-recommendation': index === 0 }"
+        >
+          <div class="rank-badge">{{ index + 1 }}</div>
+
+          <div class="card-info">
+            <div class="card-image-container">
+              <img
+                :src="card.cardImageUrl"
+                :alt="card.cardName"
+                class="card-image"
+                @error="handleImageError"
+              />
+            </div>
+
+            <div class="card-details">
+              <h4 class="card-name">{{ card.cardName }}</h4>
+              <p class="card-issuer">{{ card.issuer }}</p>
+
+              <div class="card-specs">
+                <span
+                  class="card-type"
+                  :class="getCardTypeClass(card.cardType)"
+                >
+                  {{ card.cardType }}
+                </span>
+                <span class="annual-fee">{{
+                  card.annualFee || "연회비 정보 없음"
+                }}</span>
+              </div>
+            </div>
+          </div>
+
+          <div class="benefit-info">
+            <div class="benefit-amount">
+              <span class="amount"
+                >{{ formatCurrency(card.estimatedBenefit) }}원</span
+              >
+              <span class="label">예상 혜택</span>
+            </div>
+            <div class="apply-actions">
+              <button
+                v-if="card.requestMobileUrl"
+                @click="openApplicationLink(card.requestMobileUrl)"
+                class="btn-apply mobile"
+              >
+                신청
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- 더보기 버튼 -->
+      <div class="view-more">
+        <BaseButton
+          @click="goToFullRecommendations"
+          variant="primary"
+          full-width
+        >
+          <i class="bi bi-arrow-right"></i>
+          전체 추천 카드 보기 ({{
+            recommendationData.recommendedCards.length
+          }}개)
+        </BaseButton>
+      </div>
+    </div>
+
+    <!-- 추천 안내 (거래내역 없을 때) -->
+    <div v-else class="recommendation-guide">
+      <div class="guide-icon">🎯</div>
+      <h4>카드 추천을 받으려면</h4>
+      <p>거래내역을 먼저 동기화해주세요</p>
+      <BaseButton @click="$emit('requestTransactionSync')" variant="outline">
+        거래내역 연동하기
+      </BaseButton>
+    </div>
+  </div>
+</template>
+
+<script>
+import BaseSpinner from "@/components/base/BaseSpinner.vue";
+import BaseButton from "@/components/base/BaseButton.vue";
+import cardsApi from "@/api/cards.js";
+
+export default {
+  name: "CardRecommendationSection",
+  components: {
+    BaseSpinner,
+    BaseButton,
+  },
+  props: {
+    selectedCard: {
+      type: Object,
+      default: null,
+    },
+    hasTransactions: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  emits: ["requestTransactionSync"],
+  data() {
+    return {
+      loading: false,
+      error: null,
+      recommendationData: null,
+    };
+  },
+  watch: {
+    selectedCard: {
+      handler(newCard) {
+        if (newCard && newCard.cardId && this.hasTransactions) {
+          this.loadRecommendations();
+        }
+      },
+      immediate: true,
+    },
+    hasTransactions: {
+      handler(hasTransactions) {
+        if (hasTransactions && this.selectedCard?.cardId) {
+          this.loadRecommendations();
+        }
+      },
+    },
+  },
+  methods: {
+    async loadRecommendations() {
+      if (!this.selectedCard?.cardId || !this.hasTransactions) {
+        return;
+      }
+
+      try {
+        this.loading = true;
+        this.error = null;
+
+        console.log("🎯 카드 추천 로딩 시작:", this.selectedCard.cardId);
+
+        // 1단계: 먼저 현재 카드의 혜택 조회
+        console.log("💰 현재 카드 혜택 조회 시작");
+        const benefitsResponse = await cardsApi.getCardBenefits(
+          this.selectedCard.cardId
+        );
+        console.log("✅ 현재 카드 혜택 조회 완료:", benefitsResponse);
+
+        // 2단계: 혜택 정보를 바탕으로 추천 카드 조회
+        // 저장된 추천 데이터 먼저 시도
+        try {
+          const response = await cardsApi.getSavedRecommendations(
+            this.selectedCard.cardId
+          );
+          this.recommendationData = response.data || response;
+
+          // 현재 카드 혜택 정보 추가
+          if (this.recommendationData && benefitsResponse) {
+            this.recommendationData.currentCardBenefits =
+              benefitsResponse.data || benefitsResponse;
+          }
+
+          console.log(
+            "✅ 저장된 추천 데이터 로딩 완료:",
+            this.recommendationData
+          );
+        } catch (savedError) {
+          // 저장된 데이터가 없으면 실시간 추천 조회
+          console.log("💾 저장된 추천 없음, 실시간 조회 시도");
+          const response = await cardsApi.getCardRecommendations(
+            this.selectedCard.cardId
+          );
+          this.recommendationData = response.data || response;
+
+          // 현재 카드 혜택 정보 추가
+          if (this.recommendationData && benefitsResponse) {
+            this.recommendationData.currentCardBenefits =
+              benefitsResponse.data || benefitsResponse;
+          }
+
+          console.log(
+            "✅ 실시간 추천 데이터 로딩 완료:",
+            this.recommendationData
+          );
+        }
+      } catch (error) {
+        console.error("❌ 추천 데이터 로딩 실패:", error);
+        this.error = error.message || "추천 데이터를 불러오는데 실패했습니다.";
+        this.recommendationData = null;
+      } finally {
+        this.loading = false;
+      }
+    },
+
+    getCurrentBenefit() {
+      // 현재 카드의 예상 혜택 반환 (ownedCardBenefits 배열에서 첫 번째 카드의 estimatedBenefit)
+      if (
+        this.recommendationData?.currentCardBenefits?.ownedCardBenefits
+          ?.length > 0
+      ) {
+        return this.recommendationData.currentCardBenefits.ownedCardBenefits[0]
+          .estimatedBenefit;
+      }
+      return 0;
+    },
+
+    getBenefitImprovement() {
+      if (!this.recommendationData?.recommendedCards[0]?.estimatedBenefit) {
+        return 0;
+      }
+      return (
+        this.recommendationData.recommendedCards[0].estimatedBenefit -
+        this.getCurrentBenefit()
+      );
+    },
+
+    formatCurrency(amount) {
+      if (!amount) return "0";
+      return Number(amount).toLocaleString();
+    },
+
+    getCardTypeClass(cardType) {
+      return {
+        "type-credit": cardType === "신용",
+        "type-debit": cardType === "체크",
+      };
+    },
+
+    handleImageError(event) {
+      event.target.src = "/logo.png";
+    },
+
+    openApplicationLink(url) {
+      if (url) {
+        window.open(url, "_blank", "noopener,noreferrer");
+      }
+    },
+
+    goToFullRecommendations() {
+      // selectedCard에서 올바른 cardId 추출
+      const cardId =
+        this.selectedCard?.cardId || this.selectedCard?.cardProductId;
+
+      if (cardId) {
+        console.log("🎯 전체 추천 페이지 이동:", cardId);
+        this.$router.push({
+          name: "CardRecommendation",
+          params: { cardId: cardId.toString() },
+        });
+      } else {
+        console.error("❌ 카드 ID를 찾을 수 없습니다:", this.selectedCard);
+      }
+    },
+  },
+};
+</script>
+
+<style scoped>
+.card-recommendation-section {
+  background: white;
+  border-radius: 12px;
+  padding: 24px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.section-header {
+  margin-bottom: 24px;
+  text-align: center;
+}
+
+.section-header h3 {
+  font-size: 20px;
+  font-weight: 700;
+  color: #333;
+  margin: 0 0 8px 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+}
+
+.section-subtitle {
+  font-size: 14px;
+  color: #666;
+  margin: 0;
+}
+
+.loading-state,
+.error-state,
+.no-recommendations,
+.recommendation-guide {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 32px 16px;
+  text-align: center;
+}
+
+.error-icon,
+.empty-icon,
+.guide-icon {
+  font-size: 48px;
+  margin-bottom: 16px;
+}
+
+.error-message {
+  color: #666;
+  margin-bottom: 16px;
+}
+
+.current-card-benefits {
+  background: linear-gradient(135deg, #f8f9fa 0%, #fff 100%);
+  border: 1px solid #e9ecef;
+  border-radius: 8px;
+  padding: 20px;
+  margin-bottom: 20px;
+}
+
+.current-card-benefits h4 {
+  font-size: 16px;
+  font-weight: 600;
+  color: #333;
+  margin: 0 0 16px 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.benefits-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 16px;
+}
+
+.benefit-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 4px;
+}
+
+.benefit-stat .stat-label {
+  font-size: 12px;
+  color: #666;
+}
+
+.benefit-stat .stat-value {
+  font-size: 16px;
+  font-weight: 600;
+  color: #333;
+}
+
+.benefit-stat .stat-value.current {
+  color: #2196f3;
+}
+
+.benefit-summary {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  margin-bottom: 24px;
+  padding: 16px;
+  background: linear-gradient(135deg, #f8f9fa 0%, #e3f2fd 100%);
+  border-radius: 8px;
+  flex-wrap: wrap;
+}
+
+.current-benefit,
+.recommended-benefit {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+
+.benefit-summary .label {
+  font-size: 12px;
+  color: #666;
+}
+
+.benefit-summary .amount {
+  font-size: 18px;
+  font-weight: 700;
+  color: #333;
+}
+
+.benefit-summary .amount.highlight {
+  color: #4caf50;
+}
+
+.arrow {
+  font-size: 20px;
+  color: #2196f3;
+  font-weight: bold;
+}
+
+.improvement {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 8px 12px;
+  background: #4caf50;
+  border-radius: 6px;
+  color: white;
+}
+
+.improvement-label {
+  font-size: 11px;
+}
+
+.improvement-amount {
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.recommendations-list {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.recommendation-item {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 16px;
+  border: 1px solid #eee;
+  border-radius: 8px;
+  position: relative;
+  transition: all 0.2s ease;
+}
+
+.recommendation-item:hover {
+  border-color: #2196f3;
+  transform: translateY(-1px);
+}
+
+.top-recommendation {
+  border-color: #ffd700;
+  background: linear-gradient(135deg, #fff9e6 0%, #ffffff 100%);
+}
+
+.rank-badge {
+  position: absolute;
+  top: -8px;
+  left: -8px;
+  width: 24px;
+  height: 24px;
+  background: #2196f3;
+  color: white;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.top-recommendation .rank-badge {
+  background: #ffd700;
+  color: #333;
+}
+
+.card-info {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex: 1;
+  min-width: 0;
+}
+
+.card-image-container {
+  flex-shrink: 0;
+  width: 60px;
+  height: 38px;
+  border-radius: 6px;
+  overflow: hidden;
+  background: #f5f5f5;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.card-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.card-details {
+  flex: 1;
+  min-width: 0;
+}
+
+.card-name {
+  font-size: 16px;
+  font-weight: 600;
+  color: #333;
+  margin: 0 0 4px 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.card-issuer {
+  font-size: 12px;
+  color: #666;
+  margin: 0 0 8px 0;
+}
+
+.card-specs {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.card-type {
+  display: inline-block;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 500;
+}
+
+.type-credit {
+  background: #e3f2fd;
+  color: #1976d2;
+}
+
+.type-debit {
+  background: #f3e5f5;
+  color: #7b1fa2;
+}
+
+.annual-fee {
+  font-size: 11px;
+  color: #999;
+}
+
+.benefit-info {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 8px;
+}
+
+.benefit-amount {
+  text-align: right;
+}
+
+.benefit-amount .amount {
+  display: block;
+  font-size: 16px;
+  font-weight: 700;
+  color: #4caf50;
+}
+
+.benefit-amount .label {
+  display: block;
+  font-size: 11px;
+  color: #666;
+}
+
+.btn-apply {
+  padding: 6px 12px;
+  background: #4caf50;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.btn-apply:hover {
+  background: #388e3c;
+}
+
+.view-more {
+  border-top: 1px solid #eee;
+  padding-top: 16px;
+}
+
+@media (max-width: 768px) {
+  .card-recommendation-section {
+    padding: 16px;
+  }
+
+  .benefit-summary {
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .arrow {
+    transform: rotate(90deg);
+  }
+
+  .recommendation-item {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 12px;
+  }
+
+  .card-info {
+    justify-content: center;
+  }
+
+  .benefit-info {
+    align-items: center;
+    flex-direction: row;
+    justify-content: space-between;
+  }
+}
+</style>

--- a/src/components/cards/MyCardsBenefitsDashboard.vue
+++ b/src/components/cards/MyCardsBenefitsDashboard.vue
@@ -1,0 +1,440 @@
+<template>
+  <div class="my-cards-benefits-dashboard">
+    <div class="dashboard-header">
+      <h2>보유 카드 혜택 요약</h2>
+      <button @click="refreshData" class="btn-refresh" :disabled="loading">
+        <span v-if="loading">🔄</span>
+        <span v-else>새로고침</span>
+      </button>
+    </div>
+
+    <div v-if="loading" class="loading-state">
+      <BaseSpinner />
+      <p>카드 혜택을 분석하고 있습니다...</p>
+    </div>
+
+    <div v-else-if="error" class="error-state">
+      <p>{{ error }}</p>
+      <BaseButton @click="refreshData">다시 시도</BaseButton>
+    </div>
+
+    <div v-else-if="cardsBenefits.length === 0" class="empty-state">
+      <h3>보유 카드가 없습니다</h3>
+      <p>카드를 등록하고 거래내역을 동기화해보세요.</p>
+      <RouterLink to="/mydata/cards" class="btn-link">
+        카드 등록하러 가기
+      </RouterLink>
+    </div>
+
+    <div v-else class="cards-grid">
+      <div
+        v-for="cardBenefit in cardsBenefits"
+        :key="cardBenefit.ownedCardBenefits[0]?.cardId"
+        class="card-benefit-item"
+        @click="goToRecommendation(cardBenefit.ownedCardBenefits[0]?.cardId)"
+      >
+        <div class="card-header">
+          <div class="card-info">
+            <img
+              :src="cardBenefit.ownedCardBenefits[0]?.cardImageUrl"
+              :alt="cardBenefit.ownedCardBenefits[0]?.cardName"
+              class="card-image"
+              @error="handleImageError"
+            />
+            <div class="card-details">
+              <h3 class="card-name">{{ cardBenefit.ownedCardBenefits[0]?.cardName }}</h3>
+              <p class="card-issuer">{{ cardBenefit.ownedCardBenefits[0]?.issuer }}</p>
+            </div>
+          </div>
+          <div class="benefit-amount">
+            <span class="benefit-value">
+              {{ formatCurrency(cardBenefit.ownedCardBenefits[0]?.estimatedBenefit) }}원
+            </span>
+            <span class="benefit-label">예상 혜택</span>
+          </div>
+        </div>
+
+        <div class="spending-summary">
+          <div class="summary-item">
+            <span class="label">총 소비금액</span>
+            <span class="value">{{ formatCurrency(cardBenefit.totalSpendAmount) }}원</span>
+          </div>
+          <div class="summary-item">
+            <span class="label">주요 카테고리</span>
+            <span class="value">{{ getTopCategory(cardBenefit.categoryStats) }}</span>
+          </div>
+        </div>
+
+        <div class="action-button">
+          <span class="btn-text">추천 카드 보기</span>
+          <span class="arrow">→</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- 전체 요약 -->
+    <div v-if="cardsBenefits.length > 0" class="summary-section">
+      <div class="summary-card">
+        <h3>전체 요약</h3>
+        <div class="summary-stats">
+          <div class="stat">
+            <span class="stat-value">{{ cardsBenefits.length }}</span>
+            <span class="stat-label">보유 카드</span>
+          </div>
+          <div class="stat">
+            <span class="stat-value">{{ formatCurrency(totalSpendAmount) }}원</span>
+            <span class="stat-label">총 소비금액</span>
+          </div>
+          <div class="stat">
+            <span class="stat-value">{{ formatCurrency(totalBenefitAmount) }}원</span>
+            <span class="stat-label">총 예상혜택</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import BaseSpinner from '@/components/base/BaseSpinner.vue';
+import BaseButton from '@/components/base/BaseButton.vue';
+import cardsApi from '@/api/cards.js';
+
+export default {
+  name: 'MyCardsBenefitsDashboard',
+  components: {
+    BaseSpinner,
+    BaseButton,
+  },
+  data() {
+    return {
+      loading: false,
+      error: null,
+      cardsBenefits: [],
+    };
+  },
+  computed: {
+    totalSpendAmount() {
+      return this.cardsBenefits.reduce((sum, card) => sum + (card.totalSpendAmount || 0), 0);
+    },
+    
+    totalBenefitAmount() {
+      return this.cardsBenefits.reduce((sum, card) => {
+        const benefit = card.ownedCardBenefits[0]?.estimatedBenefit || 0;
+        return sum + benefit;
+      }, 0);
+    },
+  },
+  async mounted() {
+    await this.loadData();
+  },
+  methods: {
+    async loadData() {
+      try {
+        this.loading = true;
+        this.error = null;
+        
+        const response = await cardsApi.getMyCardsBenefits();
+        this.cardsBenefits = response.data || response || [];
+        
+      } catch (error) {
+        console.error('카드 혜택 데이터 로딩 실패:', error);
+        this.error = error.message || '데이터를 불러오는데 실패했습니다.';
+      } finally {
+        this.loading = false;
+      }
+    },
+
+    async refreshData() {
+      await this.loadData();
+    },
+
+    formatCurrency(amount) {
+      if (!amount) return '0';
+      return Number(amount).toLocaleString();
+    },
+
+    getTopCategory(categoryStats) {
+      if (!categoryStats || categoryStats.length === 0) return '없음';
+      const sorted = [...categoryStats].sort((a, b) => b.totalAmount - a.totalAmount);
+      return sorted[0]?.category || '없음';
+    },
+
+    handleImageError(event) {
+      event.target.src = '/logo.png';
+    },
+
+    goToRecommendation(cardId) {
+      if (cardId) {
+        this.$router.push({
+          name: 'CardRecommendation',
+          params: { cardId: cardId.toString() }
+        });
+      }
+    },
+  },
+};
+</script>
+
+<style scoped>
+.my-cards-benefits-dashboard {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 24px;
+}
+
+.dashboard-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 24px;
+}
+
+.dashboard-header h2 {
+  font-size: 24px;
+  font-weight: 700;
+  color: #333;
+  margin: 0;
+}
+
+.btn-refresh {
+  padding: 8px 16px;
+  background: #f5f5f5;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 14px;
+  transition: background-color 0.2s ease;
+}
+
+.btn-refresh:hover:not(:disabled) {
+  background: #e9e9e9;
+}
+
+.btn-refresh:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.loading-state, .error-state, .empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 64px 24px;
+  text-align: center;
+}
+
+.empty-state h3 {
+  color: #666;
+  margin-bottom: 8px;
+}
+
+.empty-state p {
+  color: #999;
+  margin-bottom: 24px;
+}
+
+.btn-link {
+  display: inline-block;
+  padding: 12px 24px;
+  background: #2196f3;
+  color: white;
+  text-decoration: none;
+  border-radius: 8px;
+  font-weight: 500;
+  transition: background-color 0.2s ease;
+}
+
+.btn-link:hover {
+  background: #1976d2;
+}
+
+.cards-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
+  gap: 20px;
+  margin-bottom: 32px;
+}
+
+.card-benefit-item {
+  background: white;
+  border-radius: 12px;
+  padding: 20px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.card-benefit-item:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 16px;
+}
+
+.card-info {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex: 1;
+  min-width: 0;
+}
+
+.card-image {
+  width: 60px;
+  height: 38px;
+  object-fit: cover;
+  border-radius: 6px;
+  background: #f5f5f5;
+}
+
+.card-details {
+  flex: 1;
+  min-width: 0;
+}
+
+.card-name {
+  font-size: 16px;
+  font-weight: 600;
+  color: #333;
+  margin: 0 0 4px 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.card-issuer {
+  font-size: 12px;
+  color: #666;
+  margin: 0;
+}
+
+.benefit-amount {
+  text-align: right;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.benefit-value {
+  font-size: 18px;
+  font-weight: 700;
+  color: #4caf50;
+}
+
+.benefit-label {
+  font-size: 12px;
+  color: #666;
+}
+
+.spending-summary {
+  display: flex;
+  justify-content: space-between;
+  padding: 12px 0;
+  border-top: 1px solid #f0f0f0;
+  border-bottom: 1px solid #f0f0f0;
+  margin-bottom: 16px;
+}
+
+.summary-item {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.summary-item .label {
+  font-size: 12px;
+  color: #666;
+}
+
+.summary-item .value {
+  font-size: 14px;
+  font-weight: 500;
+  color: #333;
+}
+
+.action-button {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  color: #2196f3;
+  font-weight: 500;
+}
+
+.arrow {
+  font-size: 18px;
+  transition: transform 0.2s ease;
+}
+
+.card-benefit-item:hover .arrow {
+  transform: translateX(4px);
+}
+
+.summary-section {
+  margin-top: 32px;
+}
+
+.summary-card {
+  background: white;
+  border-radius: 12px;
+  padding: 24px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.summary-card h3 {
+  font-size: 20px;
+  font-weight: 600;
+  color: #333;
+  margin: 0 0 16px 0;
+}
+
+.summary-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 24px;
+}
+
+.stat {
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.stat-value {
+  font-size: 24px;
+  font-weight: 700;
+  color: #2196f3;
+}
+
+.stat-label {
+  font-size: 14px;
+  color: #666;
+}
+
+@media (max-width: 768px) {
+  .my-cards-benefits-dashboard {
+    padding: 16px;
+  }
+  
+  .cards-grid {
+    grid-template-columns: 1fr;
+  }
+  
+  .dashboard-header {
+    flex-direction: column;
+    gap: 16px;
+    align-items: stretch;
+  }
+  
+  .summary-stats {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/src/components/cards/RecommendedCardItem.vue
+++ b/src/components/cards/RecommendedCardItem.vue
@@ -1,0 +1,254 @@
+<template>
+  <div class="recommended-card-item">
+    <div class="card-header">
+      <div class="card-image">
+        <img :src="card.cardImageUrl" :alt="card.cardName" @error="handleImageError" />
+      </div>
+      <div class="card-info">
+        <h3 class="card-name">{{ card.cardName }}</h3>
+        <p class="card-issuer">{{ card.issuer }}</p>
+        <span class="card-type" :class="cardTypeClass">{{ card.cardType }}</span>
+      </div>
+      <div class="benefit-amount">
+        <span class="benefit-label">예상 혜택</span>
+        <span class="benefit-value">{{ formatCurrency(card.estimatedBenefit) }}원</span>
+      </div>
+    </div>
+    
+    <div class="card-details">
+      <div class="detail-row">
+        <span class="detail-label">연회비</span>
+        <span class="detail-value">{{ card.annualFee || '정보 없음' }}</span>
+      </div>
+      <div class="detail-row" v-if="card.preMonthMoney">
+        <span class="detail-label">전월 실적</span>
+        <span class="detail-value">{{ formatCurrency(card.preMonthMoney) }}원</span>
+      </div>
+    </div>
+
+    <div class="card-actions">
+      <button
+        class="btn-apply"
+        @click="openApplicationLink('pc')"
+        v-if="card.requestPcUrl"
+      >
+        PC에서 신청
+      </button>
+      <button
+        class="btn-apply mobile"
+        @click="openApplicationLink('mobile')"
+        v-if="card.requestMobileUrl"
+      >
+        모바일에서 신청
+      </button>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'RecommendedCardItem',
+  props: {
+    card: {
+      type: Object,
+      required: true
+    }
+  },
+  computed: {
+    cardTypeClass() {
+      return {
+        'type-credit': this.card.cardType === '신용',
+        'type-debit': this.card.cardType === '체크'
+      };
+    }
+  },
+  methods: {
+    formatCurrency(amount) {
+      if (!amount) return '0';
+      return Number(amount).toLocaleString();
+    },
+    
+    handleImageError(event) {
+      // 이미지 로드 실패 시 기본 이미지로 대체
+      event.target.src = '/logo.png';
+    },
+    
+    openApplicationLink(type) {
+      const url = type === 'pc' ? this.card.requestPcUrl : this.card.requestMobileUrl;
+      if (url) {
+        window.open(url, '_blank');
+      }
+    }
+  }
+};
+</script>
+
+<style scoped>
+.recommended-card-item {
+  background: white;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  margin-bottom: 16px;
+  padding: 20px;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.recommended-card-item:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+}
+
+.card-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.card-image {
+  flex-shrink: 0;
+  width: 80px;
+  height: 50px;
+  border-radius: 8px;
+  overflow: hidden;
+  background: #f5f5f5;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.card-image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.card-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.card-name {
+  font-size: 18px;
+  font-weight: 700;
+  color: #333;
+  margin: 0 0 4px 0;
+  line-height: 1.3;
+}
+
+.card-issuer {
+  font-size: 14px;
+  color: #666;
+  margin: 0 0 8px 0;
+}
+
+.card-type {
+  display: inline-block;
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.type-credit {
+  background: #e3f2fd;
+  color: #1976d2;
+}
+
+.type-debit {
+  background: #f3e5f5;
+  color: #7b1fa2;
+}
+
+.benefit-amount {
+  text-align: right;
+  flex-shrink: 0;
+}
+
+.benefit-label {
+  display: block;
+  font-size: 12px;
+  color: #666;
+  margin-bottom: 4px;
+}
+
+.benefit-value {
+  display: block;
+  font-size: 20px;
+  font-weight: 700;
+  color: #4caf50;
+}
+
+.card-details {
+  border-top: 1px solid #eee;
+  padding-top: 16px;
+  margin-bottom: 16px;
+}
+
+.detail-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.detail-row:last-child {
+  margin-bottom: 0;
+}
+
+.detail-label {
+  font-size: 14px;
+  color: #666;
+}
+
+.detail-value {
+  font-size: 14px;
+  font-weight: 500;
+  color: #333;
+}
+
+.card-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.btn-apply {
+  flex: 1;
+  padding: 12px 16px;
+  background: #2196f3;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.btn-apply:hover {
+  background: #1976d2;
+}
+
+.btn-apply.mobile {
+  background: #4caf50;
+}
+
+.btn-apply.mobile:hover {
+  background: #388e3c;
+}
+
+@media (max-width: 768px) {
+  .card-header {
+    flex-direction: column;
+    gap: 12px;
+  }
+  
+  .benefit-amount {
+    text-align: left;
+  }
+  
+  .card-actions {
+    flex-direction: column;
+  }
+}
+</style>

--- a/src/components/cards/SpendingCategoryChart.vue
+++ b/src/components/cards/SpendingCategoryChart.vue
@@ -1,0 +1,265 @@
+<template>
+  <div class="spending-category-chart">
+    <h3 class="chart-title">소비 패턴 분석</h3>
+    <div class="total-amount">
+      <span class="label">총 소비금액</span>
+      <span class="amount">{{ formatCurrency(totalSpendAmount) }}원</span>
+    </div>
+    
+    <div class="category-list">
+      <div
+        v-for="(category, index) in sortedCategories"
+        :key="category.category"
+        class="category-item"
+        :class="{ 'top-category': index < 3 }"
+      >
+        <div class="category-header">
+          <div class="category-info">
+            <span class="category-name">{{ category.category }}</span>
+            <span class="category-count">{{ category.transactionCount }}건</span>
+          </div>
+          <div class="category-amount">
+            <span class="amount">{{ formatCurrency(category.totalAmount) }}원</span>
+            <span class="percentage">{{ calculatePercentage(category.totalAmount) }}%</span>
+          </div>
+        </div>
+        
+        <div class="progress-bar">
+          <div
+            class="progress-fill"
+            :style="{ width: calculatePercentage(category.totalAmount) + '%' }"
+            :class="getCategoryColorClass(index)"
+          ></div>
+        </div>
+        
+        <div class="category-details">
+          <span class="avg-amount">평균 {{ formatCurrency(category.averageAmount) }}원</span>
+        </div>
+      </div>
+    </div>
+    
+    <div class="chart-summary" v-if="topCategories.length > 0">
+      <h4>주요 소비 카테고리</h4>
+      <p>
+        가장 많이 소비하는 분야는 
+        <strong>{{ topCategories[0].category }}</strong>이며,
+        전체 소비의 <strong>{{ calculatePercentage(topCategories[0].totalAmount) }}%</strong>를 차지합니다.
+      </p>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'SpendingCategoryChart',
+  props: {
+    categoryStats: {
+      type: Array,
+      default: () => []
+    },
+    totalSpendAmount: {
+      type: Number,
+      default: 0
+    }
+  },
+  computed: {
+    sortedCategories() {
+      return [...this.categoryStats].sort((a, b) => b.totalAmount - a.totalAmount);
+    },
+    
+    topCategories() {
+      return this.sortedCategories.slice(0, 3);
+    },
+    
+    actualTotalAmount() {
+      return this.categoryStats.reduce((sum, cat) => sum + cat.totalAmount, 0);
+    }
+  },
+  methods: {
+    formatCurrency(amount) {
+      if (!amount) return '0';
+      return Math.round(amount).toLocaleString();
+    },
+    
+    calculatePercentage(amount) {
+      const total = this.actualTotalAmount || 1;
+      return Math.round((amount / total) * 100);
+    },
+    
+    getCategoryColorClass(index) {
+      const colors = ['primary', 'secondary', 'tertiary', 'quaternary', 'quinary'];
+      return `color-${colors[index % colors.length]}`;
+    }
+  }
+};
+</script>
+
+<style scoped>
+.spending-category-chart {
+  background: white;
+  border-radius: 12px;
+  padding: 24px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.chart-title {
+  font-size: 20px;
+  font-weight: 700;
+  color: #333;
+  margin: 0 0 16px 0;
+}
+
+.total-amount {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  border-radius: 8px;
+  margin-bottom: 24px;
+  color: white;
+}
+
+.total-amount .label {
+  font-size: 14px;
+  opacity: 0.9;
+}
+
+.total-amount .amount {
+  font-size: 24px;
+  font-weight: 700;
+}
+
+.category-list {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.category-item {
+  padding: 16px;
+  border-radius: 8px;
+  background: #f8f9fa;
+  transition: all 0.2s ease;
+}
+
+.category-item.top-category {
+  background: linear-gradient(135deg, #f8f9fa 0%, #e3f2fd 100%);
+  border: 1px solid #e3f2fd;
+}
+
+.category-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 8px;
+}
+
+.category-info {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.category-name {
+  font-size: 16px;
+  font-weight: 600;
+  color: #333;
+}
+
+.category-count {
+  font-size: 12px;
+  color: #666;
+}
+
+.category-amount {
+  text-align: right;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.category-amount .amount {
+  font-size: 16px;
+  font-weight: 600;
+  color: #333;
+}
+
+.category-amount .percentage {
+  font-size: 12px;
+  color: #666;
+}
+
+.progress-bar {
+  height: 6px;
+  background: #e0e0e0;
+  border-radius: 3px;
+  overflow: hidden;
+  margin-bottom: 8px;
+}
+
+.progress-fill {
+  height: 100%;
+  border-radius: 3px;
+  transition: width 0.3s ease;
+}
+
+.color-primary { background: #2196f3; }
+.color-secondary { background: #4caf50; }
+.color-tertiary { background: #ff9800; }
+.color-quaternary { background: #9c27b0; }
+.color-quinary { background: #607d8b; }
+
+.category-details {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.avg-amount {
+  font-size: 12px;
+  color: #666;
+}
+
+.chart-summary {
+  margin-top: 24px;
+  padding: 16px;
+  background: #f0f7ff;
+  border-radius: 8px;
+  border-left: 4px solid #2196f3;
+}
+
+.chart-summary h4 {
+  font-size: 16px;
+  font-weight: 600;
+  color: #333;
+  margin: 0 0 8px 0;
+}
+
+.chart-summary p {
+  font-size: 14px;
+  color: #555;
+  margin: 0;
+  line-height: 1.5;
+}
+
+@media (max-width: 768px) {
+  .spending-category-chart {
+    padding: 16px;
+  }
+  
+  .total-amount {
+    flex-direction: column;
+    gap: 8px;
+    text-align: center;
+  }
+  
+  .category-header {
+    flex-direction: column;
+    gap: 8px;
+  }
+  
+  .category-amount {
+    text-align: left;
+  }
+}
+</style>

--- a/src/pages/cards/CardRecommendationPage.vue
+++ b/src/pages/cards/CardRecommendationPage.vue
@@ -1,0 +1,596 @@
+<template>
+  <div class="card-recommendation-page">
+    <!-- 헤더 -->
+    <div class="page-header">
+      <h1 class="page-title">카드 추천</h1>
+      <p class="page-subtitle">
+        거래 내역을 분석하여 더 나은 혜택의 카드를 추천해드립니다
+      </p>
+    </div>
+
+    <!-- 로딩 상태 -->
+    <div v-if="loading" class="loading-container">
+      <BaseSpinner />
+      <p>추천 카드를 분석하고 있습니다...</p>
+    </div>
+
+    <!-- 오류 상태 -->
+    <div v-else-if="error" class="error-container">
+      <div class="error-message">
+        <h3>데이터를 불러올 수 없습니다</h3>
+        <p>{{ error }}</p>
+        <BaseButton @click="loadRecommendations" class="retry-btn">
+          다시 시도
+        </BaseButton>
+      </div>
+    </div>
+
+    <!-- 메인 콘텐츠 -->
+    <div v-else class="content">
+      <!-- 카드 선택 -->
+      <div class="card-selector-section">
+        <h2>분석할 카드를 선택하세요</h2>
+        <div class="card-selector">
+          <select
+            v-model="selectedCardId"
+            @change="onCardChange"
+            class="card-select"
+          >
+            <option value="">카드를 선택하세요</option>
+            <option
+              v-for="card in userCards"
+              :key="card.holdingId || card.cardId"
+              :value="card.cardId"
+            >
+              {{ card.cardName || card.name }} ({{
+                card.issuer || card.issuerName
+              }})
+            </option>
+          </select>
+        </div>
+      </div>
+
+      <!-- 분석 결과 -->
+      <div v-if="recommendationData" class="analysis-results">
+        <!-- 소비 패턴 분석 -->
+        <div class="analysis-section">
+          <SpendingCategoryChart
+            :categoryStats="recommendationData.categoryStats"
+            :totalSpendAmount="recommendationData.totalSpendAmount"
+          />
+        </div>
+
+        <!-- 추천 카드 목록 -->
+        <div class="recommendations-section">
+          <div class="section-header">
+            <h2>추천 카드</h2>
+            <p class="section-subtitle">{{ recommendationData.message }}</p>
+          </div>
+
+          <div
+            v-if="recommendationData.recommendedCards.length === 0"
+            class="no-recommendations"
+          >
+            <div class="empty-state">
+              <h3>추천할 카드가 없습니다</h3>
+              <p>현재 사용 중인 카드가 해당 소비 패턴에 가장 적합합니다.</p>
+            </div>
+          </div>
+
+          <div v-else class="recommendations-list">
+            <RecommendedCardItem
+              v-for="(card, index) in recommendationData.recommendedCards"
+              :key="card.cardId"
+              :card="card"
+              class="recommendation-rank"
+              :class="`rank-${index + 1}`"
+            >
+              <template #rank>
+                <div class="rank-badge">{{ index + 1 }}</div>
+              </template>
+            </RecommendedCardItem>
+          </div>
+        </div>
+
+        <!-- 추천 요약 -->
+        <div class="recommendation-summary">
+          <div class="summary-card">
+            <h3>분석 요약</h3>
+            <div class="summary-stats">
+              <div class="stat-item">
+                <span class="stat-label">분석 기간</span>
+                <span class="stat-value">최근 {{ ANALYSIS_PERIOD_DAYS }}일</span>
+              </div>
+              <div class="stat-item">
+                <span class="stat-label">총 소비금액</span>
+                <span class="stat-value"
+                  >{{
+                    formatCurrency(recommendationData.totalSpendAmount)
+                  }}원</span
+                >
+              </div>
+              <div class="stat-item">
+                <span class="stat-label">추천 카드 수</span>
+                <span class="stat-value"
+                  >{{ recommendationData.recommendedCards.length }}개</span
+                >
+              </div>
+              <div
+                class="stat-item"
+                v-if="recommendationData.recommendedCards.length > 0"
+              >
+                <span class="stat-label">최대 예상 혜택</span>
+                <span class="stat-value benefit">
+                  {{
+                    formatCurrency(
+                      recommendationData.recommendedCards[0]?.estimatedBenefit
+                    )
+                  }}원
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- 처음 상태 -->
+      <div v-else class="empty-state-main">
+        <div class="empty-content">
+          <h3>카드를 선택해주세요</h3>
+          <p>거래 내역을 분석하여 더 나은 카드를 추천해드립니다.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { useAuthStore } from "@/stores/auth";
+import BaseSpinner from "@/components/base/BaseSpinner.vue";
+import BaseButton from "@/components/base/BaseButton.vue";
+import RecommendedCardItem from "@/components/cards/RecommendedCardItem.vue";
+import SpendingCategoryChart from "@/components/cards/SpendingCategoryChart.vue";
+import cardsApi from "@/api/cards.js";
+
+export default {
+  name: "CardRecommendationPage",
+  components: {
+    BaseSpinner,
+    BaseButton,
+    RecommendedCardItem,
+    SpendingCategoryChart,
+  },
+  setup() {
+    const authStore = useAuthStore();
+    return { authStore };
+  },
+  data() {
+    return {
+      loading: false,
+      error: null,
+      selectedCardId: "",
+      userCards: [],
+      recommendationData: null,
+      ANALYSIS_PERIOD_DAYS: 30, // 분석 기간 상수
+    };
+  },
+  async mounted() {
+    await this.loadUserCards();
+
+    // URL 파라미터에서 cardId 가져오기
+    const cardId = this.$route.params.cardId || this.$route.query.cardId;
+    if (cardId) {
+      this.selectedCardId = parseInt(cardId);
+      await this.loadRecommendations();
+    }
+  },
+  methods: {
+    async loadUserCards() {
+      try {
+        this.loading = true;
+        this.error = null;
+
+        const userId = this.authStore.getUserId;
+        if (!userId) {
+          this.error = "로그인이 필요합니다.";
+          this.$router.push("/login");
+          return;
+        }
+
+        console.log("📋 사용자 카드 목록 조회 시작, userId:", userId);
+        const response = await cardsApi.getUserCards(userId);
+        console.log("✅ 사용자 카드 응답:", response);
+
+        // API 응답 구조에 맞게 처리
+        this.userCards = response.result || response.data || response || [];
+
+        if (this.userCards.length === 0) {
+          this.error =
+            "등록된 카드가 없습니다. 먼저 마이데이터에서 카드를 연동해주세요.";
+        } else {
+          console.log(`💡 ${this.userCards.length}개의 카드를 불러왔습니다.`);
+        }
+      } catch (error) {
+        console.error("❌ 사용자 카드 로딩 실패:", error);
+
+        if (error.response?.status === 401) {
+          this.error = "인증이 만료되었습니다. 다시 로그인해주세요.";
+          this.authStore.logout();
+          this.$router.push("/login");
+        } else if (error.response?.status === 404) {
+          this.error =
+            "등록된 카드가 없습니다. 먼저 마이데이터에서 카드를 연동해주세요.";
+        } else {
+          this.error =
+            error.response?.data?.message ||
+            error.message ||
+            "카드 목록을 불러오는데 실패했습니다.";
+        }
+      } finally {
+        this.loading = false;
+      }
+    },
+
+    async loadRecommendations() {
+      if (!this.selectedCardId) return;
+
+      try {
+        this.loading = true;
+        this.error = null;
+
+        console.log("🎯 카드 추천 로딩 시작:", this.selectedCardId);
+
+        // 1단계: 먼저 현재 카드의 혜택 조회
+        console.log("💰 현재 카드 혜택 조회 시작");
+        const benefitsResponse = await cardsApi.getCardBenefits(this.selectedCardId);
+        console.log("✅ 현재 카드 혜택 조회 완료:", benefitsResponse);
+
+        // 2단계: 혜택 정보를 바탕으로 추천 카드 조회
+        let response;
+        try {
+          response = await cardsApi.getSavedRecommendations(this.selectedCardId);
+          console.log("✅ 저장된 추천 데이터 로딩 완료:", response);
+        } catch (savedError) {
+          // 저장된 데이터가 없으면 실시간 추천 조회
+          console.log("💾 저장된 추천 없음, 실시간 조회 시도");
+          response = await cardsApi.getCardRecommendations(this.selectedCardId);
+          console.log("✅ 실시간 추천 데이터 로딩 완료:", response);
+        }
+
+        // API 응답 구조에 맞게 처리
+        this.recommendationData = response.data || response;
+
+        // 현재 카드 혜택 정보 추가
+        if (this.recommendationData && benefitsResponse) {
+          this.recommendationData.currentCardBenefits = benefitsResponse.data || benefitsResponse;
+        }
+
+        // URL 업데이트
+        if (this.$route.params.cardId !== this.selectedCardId.toString()) {
+          this.$router.replace({
+            name: "CardRecommendation",
+            params: { cardId: this.selectedCardId },
+          });
+        }
+      } catch (error) {
+        console.error("❌ 추천 데이터 로딩 실패:", error);
+        this.error =
+          error.response?.data?.message ||
+          error.message ||
+          "추천 데이터를 불러오는데 실패했습니다.";
+        this.recommendationData = null;
+      } finally {
+        this.loading = false;
+      }
+    },
+
+    async onCardChange() {
+      if (this.selectedCardId) {
+        await this.loadRecommendations();
+      } else {
+        this.recommendationData = null;
+      }
+    },
+
+    formatCurrency(amount) {
+      if (!amount) return "0";
+      return Number(amount).toLocaleString();
+    },
+  },
+};
+</script>
+
+<style scoped>
+.card-recommendation-page {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 24px;
+}
+
+.page-header {
+  text-align: center;
+  margin-bottom: 32px;
+}
+
+.page-title {
+  font-size: 32px;
+  font-weight: 700;
+  color: #333;
+  margin: 0 0 8px 0;
+}
+
+.page-subtitle {
+  font-size: 16px;
+  color: #666;
+  margin: 0;
+}
+
+.loading-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 64px 24px;
+  text-align: center;
+}
+
+.loading-container p {
+  margin-top: 16px;
+  color: #666;
+}
+
+.error-container {
+  display: flex;
+  justify-content: center;
+  padding: 64px 24px;
+}
+
+.error-message {
+  text-align: center;
+  max-width: 400px;
+}
+
+.error-message h3 {
+  color: #f44336;
+  margin-bottom: 8px;
+}
+
+.error-message p {
+  color: #666;
+  margin-bottom: 24px;
+}
+
+.card-selector-section {
+  background: white;
+  border-radius: 12px;
+  padding: 24px;
+  margin-bottom: 24px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.card-selector-section h2 {
+  font-size: 20px;
+  font-weight: 600;
+  color: #333;
+  margin: 0 0 16px 0;
+}
+
+.card-select {
+  width: 100%;
+  padding: 12px 16px;
+  border: 2px solid #e0e0e0;
+  border-radius: 8px;
+  font-size: 16px;
+  background: white;
+  transition: border-color 0.2s ease;
+}
+
+.card-select:focus {
+  outline: none;
+  border-color: #2196f3;
+}
+
+.analysis-results {
+  display: grid;
+  gap: 24px;
+  grid-template-areas:
+    "analysis"
+    "recommendations"
+    "summary";
+}
+
+.analysis-section {
+  grid-area: analysis;
+  background: white;
+  border-radius: 12px;
+  padding: 24px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.recommendations-section {
+  grid-area: recommendations;
+  background: white;
+  border-radius: 12px;
+  padding: 24px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.section-header {
+  margin-bottom: 24px;
+}
+
+.section-header h2 {
+  font-size: 24px;
+  font-weight: 700;
+  color: #333;
+  margin: 0 0 8px 0;
+}
+
+.section-subtitle {
+  font-size: 14px;
+  color: #666;
+  margin: 0;
+}
+
+.no-recommendations {
+  display: flex;
+  justify-content: center;
+  padding: 64px 24px;
+}
+
+.empty-state {
+  text-align: center;
+  max-width: 400px;
+}
+
+.empty-state h3 {
+  color: #666;
+  margin-bottom: 8px;
+}
+
+.empty-state p {
+  color: #999;
+}
+
+.recommendations-list {
+  display: grid;
+  gap: 16px;
+}
+
+.recommendation-rank {
+  position: relative;
+}
+
+.rank-badge {
+  position: absolute;
+  top: -8px;
+  left: -8px;
+  width: 32px;
+  height: 32px;
+  background: #2196f3;
+  color: white;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 14px;
+  z-index: 1;
+}
+
+.rank-1 .rank-badge {
+  background: #ffd700;
+  color: #333;
+}
+
+.rank-2 .rank-badge {
+  background: #c0c0c0;
+  color: #333;
+}
+
+.rank-3 .rank-badge {
+  background: #cd7f32;
+  color: white;
+}
+
+.recommendation-summary {
+  grid-area: summary;
+  background: white;
+  border-radius: 12px;
+  padding: 24px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.summary-card h3 {
+  font-size: 20px;
+  font-weight: 600;
+  color: #333;
+  margin: 0 0 16px 0;
+}
+
+.summary-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 16px;
+}
+
+.stat-item {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.stat-label {
+  font-size: 14px;
+  color: #666;
+}
+
+.stat-value {
+  font-size: 18px;
+  font-weight: 600;
+  color: #333;
+}
+
+.stat-value.benefit {
+  color: #4caf50;
+}
+
+.empty-state-main {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 300px;
+}
+
+.empty-content {
+  text-align: center;
+  max-width: 400px;
+}
+
+.empty-content h3 {
+  color: #666;
+  margin-bottom: 8px;
+}
+
+.empty-content p {
+  color: #999;
+}
+
+/* 데스크탑 레이아웃 개선 */
+@media (min-width: 1024px) {
+  .analysis-results {
+    grid-template-areas:
+      "analysis recommendations"
+      "summary summary";
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .analysis-section,
+  .recommendations-section {
+    min-height: 400px;
+  }
+}
+
+@media (max-width: 768px) {
+  .card-recommendation-page {
+    padding: 16px;
+  }
+
+  .page-title {
+    font-size: 24px;
+  }
+
+  .summary-stats {
+    grid-template-columns: 1fr;
+  }
+
+  .analysis-section,
+  .recommendations-section {
+    padding: 16px;
+  }
+
+  .card-selector-section {
+    padding: 16px;
+  }
+}
+</style>

--- a/src/pages/mydata/MyDataCardPage.vue
+++ b/src/pages/mydata/MyDataCardPage.vue
@@ -29,77 +29,474 @@
         <div>거래내역을 불러오고 있습니다...</div>
       </div>
 
-      <!-- 거래내역이 있을 때: 통계와 목록 표시 -->
+      <!-- 거래내역이 있을 때: 탭과 콘텐츠 표시 -->
       <div
         v-else-if="syncedTransactions.length > 0"
         class="transactions-content"
       >
-        <!-- Desktop: 좌우 배치, Mobile: 상하 배치 -->
-        <div class="content-layout">
-          <!-- 소비 패턴 차트 섹션 (먼저 표시) -->
-          <div class="chart-section">
-            <div class="section-header">
-              <h3>
-                {{ selectedSyncedCard?.cardName || "카드" }} 소비 패턴 TOP 5
-              </h3>
-            </div>
-            <div class="pattern-chart">
-              <SpendingPatternChart :transactions="syncedTransactions" />
-            </div>
-            <div class="chart-actions">
-              <BaseButton
-                variant="primary"
-                @click="showTransactionDetails = true"
-              >
-                <i class="bi bi-bar-chart"></i>
-                전체 통계 보기
-              </BaseButton>
+        <!-- 탭 버튼들 -->
+        <div class="tab-buttons">
+          <button
+            @click="changeTab('recommendations')"
+            :class="['tab-button', { active: activeTab === 'recommendations' }]"
+          >
+            <i class="bi bi-stars"></i>
+            카드 추천
+          </button>
+          <button
+            @click="changeTab('statistics')"
+            :class="['tab-button', { active: activeTab === 'statistics' }]"
+          >
+            <i class="bi bi-bar-chart"></i>
+            소비 통계
+          </button>
+          <button
+            @click="changeTab('transactions')"
+            :class="['tab-button', { active: activeTab === 'transactions' }]"
+          >
+            <i class="bi bi-list-ul"></i>
+            거래 내역
+          </button>
+        </div>
+
+        <!-- 탭 콘텐츠 -->
+        <div class="tab-content">
+          <!-- 카드 추천 탭 -->
+          <div v-if="activeTab === 'recommendations'" class="tab-panel">
+            <div class="recommendations-tab-content">
+              <!-- 추천 요약 정보 -->
+              <div class="recommendation-summary-card card">
+                <div class="summary-header">
+                  <h3>
+                    <i class="bi bi-stars"></i>
+                    {{ selectedSyncedCard?.cardName || "현재 카드" }} 추천 분석
+                  </h3>
+                  <div class="analysis-period">
+                    <i class="bi bi-calendar3"></i>
+                    최근 {{ ANALYSIS_PERIOD_DAYS }}일 분석
+                  </div>
+                </div>
+
+                <div class="quick-stats">
+                  <div class="stat-item">
+                    <div class="stat-icon">💳</div>
+                    <div class="stat-content">
+                      <span class="stat-value"
+                        >{{ formatCurrency(getTotalSpendAmount()) }}원</span
+                      >
+                      <span class="stat-label">총 사용금액</span>
+                    </div>
+                  </div>
+                  <div class="stat-item">
+                    <div class="stat-icon">📊</div>
+                    <div class="stat-content">
+                      <span class="stat-value">{{ getTopCategory() }}</span>
+                      <span class="stat-label">주요 소비 카테고리</span>
+                    </div>
+                  </div>
+                  <div class="stat-item">
+                    <div class="stat-icon">🎯</div>
+                    <div class="stat-content">
+                      <span class="stat-value"
+                        >{{ getTransactionCount() }}건</span
+                      >
+                      <span class="stat-label">총 거래 건수</span>
+                    </div>
+                  </div>
+                  <div class="stat-item" v-if="getCurrentCardBenefit() > 0">
+                    <div class="stat-icon">💰</div>
+                    <div class="stat-content">
+                      <span class="stat-value current-benefit"
+                        >{{ formatCurrency(getCurrentCardBenefit()) }}원</span
+                      >
+                      <span class="stat-label">현재 카드 예상 혜택</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <!-- 메인 추천 섹션 -->
+              <CardRecommendationSection
+                :selectedCard="selectedSyncedCard"
+                :hasTransactions="syncedTransactions.length > 0"
+                @requestTransactionSync="handleRequestTransactionSync"
+              />
+
+              <!-- 추가 정보 섹션 -->
+              <div class="additional-info">
+                <div class="info-cards">
+                  <div class="info-card">
+                    <div class="info-header">
+                      <i class="bi bi-lightbulb"></i>
+                      <h4>추천 팁</h4>
+                    </div>
+                    <p>{{ getRecommendationTip() }}</p>
+                  </div>
+
+                  <div class="info-card">
+                    <div class="info-header">
+                      <i class="bi bi-graph-up"></i>
+                      <h4>혜택 최적화</h4>
+                    </div>
+                    <p>
+                      현재 소비 패턴을 기준으로 분석된 결과입니다. 더 많은
+                      혜택을 받으려면 추천 카드를 확인해보세요.
+                    </p>
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
 
-          <!-- 거래내역 목록 섹션 -->
-          <div class="transactions-section">
-            <div class="transactions-header">
-              <h3>최근 거래내역</h3>
-              <div class="transactions-summary">
-                <span class="total-count"
-                  >총 {{ syncedTransactions.length }}건</span
-                >
+          <!-- 소비 통계 탭 -->
+          <div v-else-if="activeTab === 'statistics'" class="tab-panel">
+            <div class="statistics-content">
+              <!-- 통계 요약 -->
+              <div class="statistics-summary">
+                <div class="summary-grid">
+                  <div class="summary-item">
+                    <div class="summary-icon">💰</div>
+                    <div class="summary-data">
+                      <span class="summary-value"
+                        >{{ formatCurrency(getTotalSpendAmount()) }}원</span
+                      >
+                      <span class="summary-label">총 사용금액</span>
+                    </div>
+                  </div>
+                  <div class="summary-item">
+                    <div class="summary-icon">📈</div>
+                    <div class="summary-data">
+                      <span class="summary-value"
+                        >{{ formatCurrency(getAverageAmount()) }}원</span
+                      >
+                      <span class="summary-label">평균 사용금액</span>
+                    </div>
+                  </div>
+                  <div class="summary-item">
+                    <div class="summary-icon">🎯</div>
+                    <div class="summary-data">
+                      <span class="summary-value"
+                        >{{ getTransactionCount() }}건</span
+                      >
+                      <span class="summary-label">총 거래건수</span>
+                    </div>
+                  </div>
+                  <div class="summary-item">
+                    <div class="summary-icon">📊</div>
+                    <div class="summary-data">
+                      <span class="summary-value"
+                        >{{ getCategoriesCount() }}개</span
+                      >
+                      <span class="summary-label">사용 카테고리</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <!-- 메인 차트 섹션 -->
+              <div class="chart-section">
+                <div class="section-header">
+                  <h3>
+                    <i class="bi bi-pie-chart"></i>
+                    {{ selectedSyncedCard?.cardName || "카드" }} 소비 패턴 TOP 5
+                  </h3>
+                  <div class="chart-period">
+                    최근 {{ ANALYSIS_PERIOD_DAYS }}일
+                  </div>
+                </div>
+                <div class="pattern-chart">
+                  <SpendingPatternChart
+                    :transactions="getFilteredTransactionsByDate()"
+                  />
+                </div>
+              </div>
+
+              <!-- 상세 분석 -->
+              <div class="detailed-analysis">
+                <div class="analysis-grid">
+                  <!-- 카테고리별 상세 -->
+                  <div class="analysis-card">
+                    <div class="analysis-header">
+                      <h4>
+                        <i class="bi bi-tags"></i>
+                        카테고리별 분석
+                      </h4>
+                    </div>
+                    <div class="category-list">
+                      <div
+                        v-for="(category, index) in getTopCategories()"
+                        :key="index"
+                        class="category-item"
+                      >
+                        <div class="category-info">
+                          <span class="category-name">{{ category.name }}</span>
+                          <span class="category-amount"
+                            >{{ formatCurrency(category.amount) }}원</span
+                          >
+                        </div>
+                        <div class="category-bar">
+                          <div
+                            class="category-fill"
+                            :style="{ width: category.percentage + '%' }"
+                          ></div>
+                        </div>
+                        <span class="category-percentage"
+                          >{{ category.percentage }}%</span
+                        >
+                      </div>
+                    </div>
+                  </div>
+
+                  <!-- 시간대별 분석 -->
+                  <div class="analysis-card">
+                    <div class="analysis-header">
+                      <h4>
+                        <i class="bi bi-clock"></i>
+                        결제 패턴 분석
+                      </h4>
+                    </div>
+                    <div class="pattern-insights">
+                      <div class="insight-item">
+                        <span class="insight-label">가장 활발한 요일</span>
+                        <span class="insight-value">{{
+                          getMostActiveDay()
+                        }}</span>
+                      </div>
+                      <div class="insight-item">
+                        <span class="insight-label">평균 일일 사용액</span>
+                        <span class="insight-value"
+                          >{{ formatCurrency(getDailyAverage()) }}원</span
+                        >
+                      </div>
+                      <div class="insight-item">
+                        <span class="insight-label">최대 사용 금액</span>
+                        <span class="insight-value"
+                          >{{ formatCurrency(getMaxAmount()) }}원</span
+                        >
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <!-- 액션 버튼 -->
+              <div class="chart-actions">
                 <BaseButton
                   variant="primary"
                   @click="showTransactionDetails = true"
                 >
-                  거래내역 더 보기
+                  <i class="bi bi-bar-chart"></i>
+                  전체 통계 보기
+                </BaseButton>
+                <BaseButton variant="outline" @click="exportStatistics">
+                  <i class="bi bi-download"></i>
+                  통계 내보내기
                 </BaseButton>
               </div>
             </div>
+          </div>
 
-            <div class="transactions-list">
-              <div
-                v-for="(transaction, index) in syncedTransactions.slice(0, 3)"
-                :key="index"
-                class="transaction-item"
-              >
-                <div class="transaction-info">
-                  <div class="transaction-date">
-                    {{ formatDate(transaction.transactionDate) }}
+          <!-- 거래 내역 탭 -->
+          <div v-else-if="activeTab === 'transactions'" class="tab-panel">
+            <div class="transactions-tab-content">
+              <!-- 검색 및 필터 -->
+              <div class="transaction-filters">
+                <div class="filter-row">
+                  <div class="search-box">
+                    <i class="bi bi-search"></i>
+                    <input
+                      v-model="searchQuery"
+                      placeholder="가맹점명 또는 카테고리 검색"
+                      class="search-input"
+                    />
                   </div>
-                  <div class="transaction-details">
-                    <div class="merchant-name">
-                      {{ transaction.merchantName }}
+                  <div class="filter-buttons">
+                    <select v-model="categoryFilter" class="filter-select">
+                      <option value="">전체 카테고리</option>
+                      <option
+                        v-for="category in getUniqueCategories()"
+                        :key="category"
+                        :value="category"
+                      >
+                        {{ category }}
+                      </option>
+                    </select>
+                    <select v-model="amountFilter" class="filter-select">
+                      <option value="">전체 금액</option>
+                      <option value="small">10만원 미만</option>
+                      <option value="medium">10만원~50만원</option>
+                      <option value="large">50만원 이상</option>
+                    </select>
+                  </div>
+                </div>
+              </div>
+
+              <!-- 거래내역 통계 요약 -->
+              <div class="transaction-stats">
+                <div class="stats-grid">
+                  <div class="stat-card">
+                    <div class="stat-icon">📊</div>
+                    <div class="stat-info">
+                      <span class="stat-number">{{
+                        getAllTransactionCount()
+                      }}</span>
+                      <span class="stat-text">총 거래</span>
                     </div>
-                    <div class="transaction-type">
-                      {{
-                        transaction.merchantCategory || transaction.paymentType
-                      }}
+                  </div>
+                  <div class="stat-card">
+                    <div class="stat-icon">💰</div>
+                    <div class="stat-info">
+                      <span class="stat-number"
+                        >{{ formatCurrency(getFilteredTotal()) }}원</span
+                      >
+                      <span class="stat-text">총 금액</span>
+                    </div>
+                  </div>
+                  <div class="stat-card">
+                    <div class="stat-icon">📈</div>
+                    <div class="stat-info">
+                      <span class="stat-number"
+                        >{{ formatCurrency(getFilteredAverage()) }}원</span
+                      >
+                      <span class="stat-text">평균 금액</span>
                     </div>
                   </div>
                 </div>
-                <div
-                  class="transaction-amount"
-                  :class="getAmountClass(transaction.amount)"
-                >
-                  {{ formatAmount(transaction.amount) }}원
+              </div>
+
+              <!-- 거래내역 목록 -->
+              <div class="transactions-section">
+                <div class="transactions-header">
+                  <h3>
+                    <i class="bi bi-list-ul"></i>
+                    거래내역 목록
+                  </h3>
+                  <div class="transactions-summary">
+                    <span class="total-count">
+                      {{ getAllTransactionCount() }}개 거래 표시 중
+                    </span>
+                    <BaseButton
+                      variant="primary"
+                      @click="showTransactionDetails = true"
+                    >
+                      <i class="bi bi-eye"></i>
+                      전체 보기
+                    </BaseButton>
+                  </div>
+                </div>
+
+                <!-- 정렬 옵션 -->
+                <div class="sort-options">
+                  <div class="sort-buttons">
+                    <button
+                      @click="changeSortOrder('date')"
+                      :class="['sort-btn', { active: sortBy === 'date' }]"
+                    >
+                      <i class="bi bi-calendar"></i>
+                      날짜순
+                    </button>
+                    <button
+                      @click="changeSortOrder('amount')"
+                      :class="['sort-btn', { active: sortBy === 'amount' }]"
+                    >
+                      <i class="bi bi-currency-dollar"></i>
+                      금액순
+                    </button>
+                    <button
+                      @click="changeSortOrder('merchant')"
+                      :class="['sort-btn', { active: sortBy === 'merchant' }]"
+                    >
+                      <i class="bi bi-shop"></i>
+                      가맹점순
+                    </button>
+                  </div>
+                </div>
+
+                <div class="transactions-list">
+                  <div
+                    v-for="(transaction, index) in getPaginatedTransactions()"
+                    :key="index"
+                    class="transaction-item enhanced"
+                  >
+                    <div class="transaction-info">
+                      <div class="transaction-main">
+                        <div class="transaction-date">
+                          <i class="bi bi-calendar3"></i>
+                          {{ formatDate(transaction.transactionDate) }}
+                        </div>
+                        <div class="transaction-details">
+                          <div class="merchant-name">
+                            <i class="bi bi-shop"></i>
+                            {{ transaction.merchantName }}
+                          </div>
+                          <div class="transaction-type">
+                            <i class="bi bi-tag"></i>
+                            {{
+                              transaction.merchantCategory ||
+                              transaction.paymentType ||
+                              "기타"
+                            }}
+                          </div>
+                        </div>
+                      </div>
+                      <div class="transaction-meta">
+                        <span class="transaction-time">
+                          {{ formatTime(transaction.transactionDate) }}
+                        </span>
+                        <span class="transaction-status">
+                          <i class="bi bi-check-circle text-success"></i>
+                          완료
+                        </span>
+                      </div>
+                    </div>
+                    <div class="transaction-amount-section">
+                      <div
+                        class="transaction-amount"
+                        :class="getAmountClass(transaction.amount)"
+                      >
+                        {{ formatAmount(transaction.amount) }}원
+                      </div>
+                      <div class="amount-details">
+                        <span class="payment-method">
+                          <i class="bi bi-credit-card"></i>
+                          {{ selectedSyncedCard?.cardName || "카드" }}
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                <!-- 페이지네이션 -->
+                <div class="pagination" v-if="getTotalPages() > 1">
+                  <button
+                    @click="changePage(currentPage - 1)"
+                    :disabled="currentPage <= 1"
+                    class="page-btn"
+                  >
+                    <i class="bi bi-chevron-left"></i>
+                  </button>
+                  <span class="page-info">
+                    {{ currentPage }} / {{ getTotalPages() }}
+                  </span>
+                  <button
+                    @click="changePage(currentPage + 1)"
+                    :disabled="currentPage >= getTotalPages()"
+                    class="page-btn"
+                  >
+                    <i class="bi bi-chevron-right"></i>
+                  </button>
+                </div>
+
+                <!-- 액션 버튼 -->
+                <div class="transaction-actions">
+                  <BaseButton variant="outline" @click="exportTransactions">
+                    <i class="bi bi-download"></i>
+                    거래내역 내보내기
+                  </BaseButton>
+                  <BaseButton variant="outline" @click="syncTransactions">
+                    <i class="bi bi-arrow-clockwise"></i>
+                    새로고침
+                  </BaseButton>
                 </div>
               </div>
             </div>
@@ -110,7 +507,7 @@
       <!-- 카드는 있지만 거래내역이 없을 때: 소비 패턴 기반 카드 추천 안내 -->
       <div
         v-else-if="cards.length > 0 && syncedTransactions.length === 0"
-        class="recommendation-guide"
+        class="recommendation-guide card"
       >
         <div class="guide-content">
           <div class="guide-icon">
@@ -207,6 +604,7 @@ import CardSyncModal from "@/components/cards/CardSyncModal.vue";
 import TransactionSyncModal from "@/components/cards/TransactionSyncModal.vue";
 import TransactionDetailModal from "@/components/cards/TransactionDetailModal.vue";
 import SpendingPatternChart from "@/components/charts/SpendingPatternChart.vue";
+import CardRecommendationSection from "@/components/cards/CardRecommendationSection.vue";
 import cardsApi from "@/api/cards";
 
 const router = useRouter();
@@ -220,6 +618,43 @@ const selectedCard = ref(null);
 const syncedTransactions = ref([]);
 const selectedSyncedCard = ref(null);
 const showTransactionDetails = ref(false);
+const activeTab = ref("recommendations"); // 'recommendations', 'statistics', 'transactions'
+const currentCardBenefits = ref(null); // 현재 카드의 혜택 정보
+
+// 분석 기간 상수
+const ANALYSIS_PERIOD_DAYS = 30;
+
+// 날짜 필터링 함수 - 최근 30일 데이터만 추출
+const getFilteredTransactionsByDate = () => {
+  const today = new Date();
+  const thirtyDaysAgo = new Date(
+    today.getTime() - ANALYSIS_PERIOD_DAYS * 24 * 60 * 60 * 1000
+  );
+
+  return syncedTransactions.value.filter((transaction) => {
+    if (!transaction.transactionDate) return false;
+
+    // YYYYMMDD 형식을 Date 객체로 변환
+    const dateStr = transaction.transactionDate.toString();
+    if (dateStr.length !== 8) return false;
+
+    const year = parseInt(dateStr.substring(0, 4));
+    const month = parseInt(dateStr.substring(4, 6)) - 1; // 월은 0부터 시작
+    const day = parseInt(dateStr.substring(6, 8));
+    const transactionDate = new Date(year, month, day);
+
+    // 최근 30일 내 거래인지 확인
+    return transactionDate >= thirtyDaysAgo && transactionDate <= today;
+  });
+};
+
+// 거래내역 필터링 및 검색
+const searchQuery = ref("");
+const categoryFilter = ref("");
+const amountFilter = ref("");
+const sortBy = ref("date");
+const currentPage = ref(1);
+const itemsPerPage = 10;
 
 const userId = computed(() => authStore.getUserId);
 
@@ -264,6 +699,21 @@ const fetchCards = async () => {
     }
   } finally {
     isLoading.value = false;
+  }
+};
+
+// 현재 카드 혜택 조회
+const loadCurrentCardBenefits = async (card) => {
+  if (!card || !card.cardId) return;
+
+  try {
+    console.log("💰 현재 카드 혜택 조회 시작:", card.cardId);
+    const response = await cardsApi.getCardBenefits(card.cardId);
+    currentCardBenefits.value = response.data || response;
+    console.log("✅ 현재 카드 혜택 조회 완료:", currentCardBenefits.value);
+  } catch (error) {
+    console.error("❌ 현재 카드 혜택 조회 실패:", error);
+    currentCardBenefits.value = null;
   }
 };
 
@@ -374,10 +824,13 @@ const handleCardSync = async (syncData) => {
   }
 };
 
-// 카드 슬라이더에서 카드 변경 시 거래내역 조회
+// 카드 슬라이더에서 카드 변경 시 거래내역 및 카드 혜택 조회
 const handleCardChange = async (card) => {
   // console.log("🔄 카드 변경:", card.cardName);
-  await loadExistingTransactions(card);
+  await Promise.all([
+    loadExistingTransactions(card),
+    loadCurrentCardBenefits(card),
+  ]);
 };
 
 // 카드 업데이트 (CardSyncModal 표시)
@@ -412,6 +865,19 @@ const formatAmount = (amount) => {
 const getAmountClass = (amount) => {
   if (!amount) return "";
   return amount < 0 ? "negative" : "positive";
+};
+
+// 탭 변경 처리
+const changeTab = (tabName) => {
+  activeTab.value = tabName;
+};
+
+// 카드 추천 섹션에서 거래내역 동기화 요청 처리
+const handleRequestTransactionSync = () => {
+  if (cards.value.length > 0) {
+    selectedCard.value = cards.value[0];
+    showTransactionModal.value = true;
+  }
 };
 
 // 거래내역 동기화 처리
@@ -477,20 +943,353 @@ const handleTransactionSync = async (transactionData) => {
   }
 };
 
+// 데이터 분석 헬퍼 메서드들 (최근 30일 데이터만 사용)
+const getTotalSpendAmount = () => {
+  const filteredTransactions = getFilteredTransactionsByDate();
+  return filteredTransactions.reduce((total, transaction) => {
+    return total + Math.abs(transaction.amount || 0);
+  }, 0);
+};
+
+const getAverageAmount = () => {
+  const total = getTotalSpendAmount();
+  const filteredTransactions = getFilteredTransactionsByDate();
+  const count = filteredTransactions.length;
+  return count > 0 ? Math.round(total / count) : 0;
+};
+
+const getTransactionCount = () => {
+  const filteredTransactions = getFilteredTransactionsByDate();
+  return filteredTransactions.length;
+};
+
+const getCategoriesCount = () => {
+  const categories = new Set();
+  const filteredTransactions = getFilteredTransactionsByDate();
+  filteredTransactions.forEach((transaction) => {
+    const category =
+      transaction.merchantCategory || transaction.paymentType || "기타";
+    categories.add(category);
+  });
+  return categories.size;
+};
+
+const getTopCategory = () => {
+  const categoryTotals = {};
+  const filteredTransactions = getFilteredTransactionsByDate();
+  filteredTransactions.forEach((transaction) => {
+    const category =
+      transaction.merchantCategory || transaction.paymentType || "기타";
+    const amount = Math.abs(transaction.amount || 0);
+    categoryTotals[category] = (categoryTotals[category] || 0) + amount;
+  });
+
+  const sortedCategories = Object.entries(categoryTotals).sort(
+    (a, b) => b[1] - a[1]
+  );
+
+  return sortedCategories.length > 0 ? sortedCategories[0][0] : "없음";
+};
+
+const getTopCategories = () => {
+  const categoryTotals = {};
+  const total = getTotalSpendAmount();
+  const filteredTransactions = getFilteredTransactionsByDate();
+
+  filteredTransactions.forEach((transaction) => {
+    const category =
+      transaction.merchantCategory || transaction.paymentType || "기타";
+    const amount = Math.abs(transaction.amount || 0);
+    categoryTotals[category] = (categoryTotals[category] || 0) + amount;
+  });
+
+  return Object.entries(categoryTotals)
+    .map(([name, amount]) => ({
+      name,
+      amount,
+      percentage: total > 0 ? Math.round((amount / total) * 100) : 0,
+    }))
+    .sort((a, b) => b.amount - a.amount)
+    .slice(0, 5);
+};
+
+const getMostActiveDay = () => {
+  const dayTotals = {};
+  const days = ["일", "월", "화", "수", "목", "금", "토"];
+  const filteredTransactions = getFilteredTransactionsByDate();
+
+  filteredTransactions.forEach((transaction) => {
+    if (transaction.transactionDate) {
+      const dateStr = transaction.transactionDate.toString();
+      const date = new Date(
+        dateStr.substr(0, 4),
+        parseInt(dateStr.substr(4, 2)) - 1,
+        dateStr.substr(6, 2)
+      );
+      const dayName = days[date.getDay()];
+      dayTotals[dayName] = (dayTotals[dayName] || 0) + 1;
+    }
+  });
+
+  const sortedDays = Object.entries(dayTotals).sort((a, b) => b[1] - a[1]);
+
+  return sortedDays.length > 0 ? `${sortedDays[0][0]}요일` : "없음";
+};
+
+const getDailyAverage = () => {
+  const total = getTotalSpendAmount();
+  return Math.round(total / ANALYSIS_PERIOD_DAYS);
+};
+
+const getMaxAmount = () => {
+  const filteredTransactions = getFilteredTransactionsByDate();
+  return filteredTransactions.reduce((max, transaction) => {
+    const amount = Math.abs(transaction.amount || 0);
+    return amount > max ? amount : max;
+  }, 0);
+};
+
+const getRecommendationTip = () => {
+  const topCategory = getTopCategory();
+  const tips = {
+    편의점:
+      "편의점 이용이 많으시네요! 편의점 할인 혜택이 있는 카드를 확인해보세요.",
+    마트: "마트 사용이 많으시네요! 생활용품 구매 시 할인 혜택이 있는 카드를 추천합니다.",
+    주유소:
+      "주유소 이용이 많으시네요! 주유 할인 혜택이 있는 카드를 확인해보세요.",
+    카페: "카페 이용이 많으시네요! 카페 적립이나 할인 혜택이 있는 카드를 추천합니다.",
+    외식: "외식 이용이 많으시네요! 음식점 할인 혜택이 있는 카드를 확인해보세요.",
+  };
+
+  return (
+    tips[topCategory] ||
+    "다양한 카테고리에서 사용하고 계시네요! 통합 혜택 카드를 확인해보세요."
+  );
+};
+
+// 거래내역 필터링 메서드들 (전체 데이터 기준)
+const getUniqueCategories = () => {
+  const categories = new Set();
+  syncedTransactions.value.forEach((transaction) => {
+    const category =
+      transaction.merchantCategory || transaction.paymentType || "기타";
+    categories.add(category);
+  });
+  return Array.from(categories).sort();
+};
+
+// 거래내역 탭용 - 전체 60일 데이터에서 사용자 검색/필터 조건만 적용
+const getAllFilteredTransactions = () => {
+  let filtered = [...syncedTransactions.value];
+
+  // 검색 필터
+  if (searchQuery.value) {
+    const query = searchQuery.value.toLowerCase();
+    filtered = filtered.filter(
+      (transaction) =>
+        (transaction.merchantName || "").toLowerCase().includes(query) ||
+        (transaction.merchantCategory || "").toLowerCase().includes(query) ||
+        (transaction.paymentType || "").toLowerCase().includes(query)
+    );
+  }
+
+  // 카테고리 필터
+  if (categoryFilter.value) {
+    filtered = filtered.filter((transaction) => {
+      const category =
+        transaction.merchantCategory || transaction.paymentType || "기타";
+      return category === categoryFilter.value;
+    });
+  }
+
+  // 금액 필터
+  if (amountFilter.value) {
+    filtered = filtered.filter((transaction) => {
+      const amount = Math.abs(transaction.amount || 0);
+      switch (amountFilter.value) {
+        case "small":
+          return amount < 100000;
+        case "medium":
+          return amount >= 100000 && amount <= 500000;
+        case "large":
+          return amount > 500000;
+        default:
+          return true;
+      }
+    });
+  }
+
+  // 정렬
+  filtered.sort((a, b) => {
+    switch (sortBy.value) {
+      case "amount":
+        return Math.abs(b.amount || 0) - Math.abs(a.amount || 0);
+      case "merchant":
+        return (a.merchantName || "").localeCompare(b.merchantName || "");
+      case "date":
+      default:
+        return (b.transactionDate || "").localeCompare(a.transactionDate || "");
+    }
+  });
+
+  return filtered;
+};
+
+// 통계용 - 최근 30일 데이터에서 사용자 검색/필터 조건 적용 (기존 함수명 유지)
+const getFilteredTransactions = () => {
+  // 먼저 최근 30일 데이터로 필터링
+  let filtered = [...getFilteredTransactionsByDate()];
+
+  // 검색 필터
+  if (searchQuery.value) {
+    const query = searchQuery.value.toLowerCase();
+    filtered = filtered.filter(
+      (transaction) =>
+        (transaction.merchantName || "").toLowerCase().includes(query) ||
+        (transaction.merchantCategory || "").toLowerCase().includes(query) ||
+        (transaction.paymentType || "").toLowerCase().includes(query)
+    );
+  }
+
+  // 카테고리 필터
+  if (categoryFilter.value) {
+    filtered = filtered.filter((transaction) => {
+      const category =
+        transaction.merchantCategory || transaction.paymentType || "기타";
+      return category === categoryFilter.value;
+    });
+  }
+
+  // 금액 필터
+  if (amountFilter.value) {
+    filtered = filtered.filter((transaction) => {
+      const amount = Math.abs(transaction.amount || 0);
+      switch (amountFilter.value) {
+        case "small":
+          return amount < 100000;
+        case "medium":
+          return amount >= 100000 && amount <= 500000;
+        case "large":
+          return amount > 500000;
+        default:
+          return true;
+      }
+    });
+  }
+
+  // 정렬
+  filtered.sort((a, b) => {
+    switch (sortBy.value) {
+      case "amount":
+        return Math.abs(b.amount || 0) - Math.abs(a.amount || 0);
+      case "merchant":
+        return (a.merchantName || "").localeCompare(b.merchantName || "");
+      case "date":
+      default:
+        return (b.transactionDate || "").localeCompare(a.transactionDate || "");
+    }
+  });
+
+  return filtered;
+};
+
+const getFilteredTotal = () => {
+  return getFilteredTransactions().reduce((total, transaction) => {
+    return total + Math.abs(transaction.amount || 0);
+  }, 0);
+};
+
+const getFilteredAverage = () => {
+  const filtered = getFilteredTransactions();
+  const total = getFilteredTotal();
+  return filtered.length > 0 ? Math.round(total / filtered.length) : 0;
+};
+
+const getPaginatedTransactions = () => {
+  const filtered = getAllFilteredTransactions(); // 거래내역 탭에서는 전체 데이터 사용
+  const start = (currentPage.value - 1) * itemsPerPage;
+  const end = start + itemsPerPage;
+  return filtered.slice(start, end);
+};
+
+const getTotalPages = () => {
+  return Math.ceil(getAllFilteredTransactions().length / itemsPerPage); // 거래내역 탭에서는 전체 데이터 사용
+};
+
+// 거래내역 탭용 - 전체 데이터 기준 통계
+const getAllTransactionCount = () => {
+  return getAllFilteredTransactions().length;
+};
+
+const getAllFilteredTotal = () => {
+  return getAllFilteredTransactions().reduce((total, transaction) => {
+    return total + Math.abs(transaction.amount || 0);
+  }, 0);
+};
+
+const getAllFilteredAverage = () => {
+  const filtered = getAllFilteredTransactions();
+  const total = getAllFilteredTotal();
+  return filtered.length > 0 ? Math.round(total / filtered.length) : 0;
+};
+
+const changeSortOrder = (newSortBy) => {
+  sortBy.value = newSortBy;
+  currentPage.value = 1;
+};
+
+const changePage = (newPage) => {
+  if (newPage >= 1 && newPage <= getTotalPages()) {
+    currentPage.value = newPage;
+  }
+};
+
+const formatTime = (dateString) => {
+  if (!dateString) return "";
+  // YYYYMMDD 형식에서 시간은 없으므로 기본값 반환
+  return "오전";
+};
+
+// 액션 메서드들
+const exportStatistics = () => {
+  // 통계 내보내기 로직
+  alert("통계 데이터를 내보냅니다.");
+};
+
+const exportTransactions = () => {
+  // 거래내역 내보내기 로직
+  alert("거래내역을 내보냅니다.");
+};
+
+const syncTransactions = () => {
+  // 거래내역 새로고침 로직
+  if (selectedSyncedCard.value) {
+    loadExistingTransactions(selectedSyncedCard.value);
+  }
+};
+
+const formatCurrency = (amount) => {
+  if (!amount) return "0";
+  return Number(amount).toLocaleString();
+};
+
+const getCurrentCardBenefit = () => {
+  // 현재 카드의 예상 혜택 반환
+  if (currentCardBenefits.value?.ownedCardBenefits?.length > 0) {
+    return currentCardBenefits.value.ownedCardBenefits[0].estimatedBenefit;
+  }
+  return 0;
+};
+
 onMounted(() => {
   fetchCards();
 });
 </script>
 
 <style scoped>
-* {
-  margin: 0;
-  padding: 0;
-  box-sizing: border-box;
-}
+/* main.css에서 이미 전역적으로 설정됨 */
 
 .card-recommendations {
-  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
   color: var(--text-primary);
   line-height: 1.6;
   width: 100%;
@@ -500,7 +1299,7 @@ onMounted(() => {
 }
 
 .main-content {
-  max-width: 1000px;
+  max-width: 1200px;
   margin: 0 auto;
 }
 
@@ -512,7 +1311,7 @@ onMounted(() => {
   margin-bottom: var(--spacing-2xl);
 }
 
-/* 연동 섹션 */
+/* 연동 섹션 - main.css card 클래스 사용 */
 .sync-section {
   text-align: center;
   padding: var(--spacing-2xl) var(--spacing-lg);
@@ -520,12 +1319,6 @@ onMounted(() => {
   border-radius: 16px;
   margin-bottom: var(--spacing-2xl);
   border: 1px solid var(--border-light);
-}
-
-.sync-info p {
-  color: var(--text-secondary);
-  margin-bottom: var(--spacing-lg);
-  font-size: var(--font-size-base);
 }
 
 /* 카드 슬라이더 */
@@ -644,15 +1437,12 @@ onMounted(() => {
   color: var(--color-error, #dc2626);
 }
 
-/* 추천 안내 섹션 */
+/* 추천 안내 섹션 - card 클래스와 gradient 결합 */
 .recommendation-guide {
   background: var(--gradient-accent);
-  border-radius: 20px;
-  padding: var(--spacing-2xl);
-  margin-bottom: var(--spacing-2xl);
   color: var(--color-white);
   text-align: center;
-  box-shadow: var(--shadow-lg);
+  margin-bottom: var(--spacing-2xl);
   border: 1px solid var(--color-dark-20);
 }
 
@@ -796,17 +1586,15 @@ onMounted(() => {
 
 /* 로딩 애니메이션 */
 .loading {
-  text-align: center;
-  padding: 40px;
-  color: var(--color-title, #636363);
+  color: var(--color-title);
 }
 
 .transactions-loading {
-  background: var(--bg-card, #fff);
+  background: var(--bg-card);
   border-radius: 16px;
-  margin-bottom: var(--spacing-xl, 30px);
-  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
-  border: 1px solid var(--border-light, #e5e7eb);
+  margin-bottom: var(--spacing-xl);
+  box-shadow: var(--shadow-md);
+  border: 1px solid var(--border-light);
 }
 
 .pattern-chart {
@@ -816,6 +1604,632 @@ onMounted(() => {
   box-shadow: var(--shadow-sm);
   border: 1px solid var(--border-light);
   flex: 1;
+}
+
+/* 탭 버튼 스타일링 - main.css 변수 활용 */
+.tab-buttons {
+  display: flex;
+  gap: 0;
+  margin-bottom: var(--spacing-xl);
+  background: var(--bg-card);
+  border-radius: 12px;
+  padding: var(--spacing-xs);
+  box-shadow: var(--shadow-sm);
+  border: 1px solid var(--border-light);
+}
+
+.tab-button {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-sm) var(--spacing-md);
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: var(--font-size-base);
+  font-weight: 500;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  white-space: nowrap;
+}
+
+.tab-button:hover {
+  background: var(--color-secondary-10);
+  color: var(--color-accent);
+}
+
+.tab-button.active {
+  background: var(--color-primary);
+  color: var(--color-black);
+  box-shadow: 0 2px px rgba(33, 150, 243, 0.3);
+}
+
+.tab-button i {
+  font-size: 16px;
+}
+
+/* 탭 콘텐츠 스타일링 */
+.tab-content {
+  width: 100%;
+}
+
+.tab-panel {
+  width: 100%;
+  animation: fadeIn 0.3s ease;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* 통계 콘텐츠 스타일링 */
+.statistics-content {
+  width: 100%;
+}
+
+/* 카드 추천 탭 상세 스타일링 */
+.recommendations-tab-content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xl);
+}
+
+.recommendation-summary-card {
+  background: var(--bg-card);
+  border-radius: 12px;
+  padding: var(--spacing-xl);
+  box-shadow: var(--shadow-md);
+  border: 1px solid var(--border-light);
+}
+
+.summary-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--spacing-lg);
+}
+
+.summary-header h3 {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: var(--font-size-xl);
+  font-weight: 700;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.analysis-period {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+  background: var(--bg-light);
+  padding: 4px 8px;
+  border-radius: 6px;
+}
+
+.quick-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: var(--spacing-lg);
+}
+
+.stat-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: var(--spacing-md);
+  background: var(--bg-light);
+  border-radius: 8px;
+}
+
+.stat-icon {
+  font-size: 24px;
+}
+
+.stat-content {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.stat-value {
+  font-size: var(--font-size-lg);
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.stat-value.current-benefit {
+  color: #4caf50;
+}
+
+.stat-label {
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+}
+
+.additional-info {
+  margin-top: var(--spacing-xl);
+}
+
+.info-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: var(--spacing-lg);
+}
+
+.info-card {
+  background: var(--bg-card);
+  border-radius: 8px;
+  padding: var(--spacing-lg);
+  border: 1px solid var(--border-light);
+}
+
+.info-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: var(--spacing-sm);
+}
+
+.info-header h4 {
+  margin: 0;
+  font-size: var(--font-size-base);
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.info-card p {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+/* 소비 통계 탭 상세 스타일링 */
+.statistics-summary {
+  background: var(--bg-card);
+  border-radius: 12px;
+  padding: var(--spacing-xl);
+  margin-bottom: var(--spacing-xl);
+  box-shadow: var(--shadow-md);
+}
+
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: var(--spacing-lg);
+}
+
+.summary-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: var(--spacing-md);
+  background: var(--bg-light);
+  border-radius: 8px;
+}
+
+.summary-icon {
+  font-size: 32px;
+}
+
+.summary-data {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.summary-value {
+  font-size: var(--font-size-lg);
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.summary-label {
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+}
+
+.chart-period {
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+  background: var(--bg-light);
+  padding: 4px 8px;
+  border-radius: 6px;
+}
+
+.detailed-analysis {
+  margin-top: var(--spacing-xl);
+}
+
+.analysis-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
+  gap: var(--spacing-xl);
+}
+
+.analysis-card {
+  background: var(--bg-card);
+  border-radius: 12px;
+  padding: var(--spacing-lg);
+  box-shadow: var(--shadow-sm);
+  border: 1px solid var(--border-light);
+}
+
+.analysis-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: var(--spacing-md);
+  padding-bottom: var(--spacing-sm);
+  border-bottom: 1px solid var(--border-light);
+}
+
+.analysis-header h4 {
+  margin: 0;
+  font-size: var(--font-size-base);
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.category-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.category-item {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-sm);
+  background: var(--bg-light);
+  border-radius: 6px;
+}
+
+.category-info {
+  display: flex;
+  justify-content: space-between;
+  width: 120px;
+  font-size: var(--font-size-sm);
+}
+
+.category-name {
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.category-amount {
+  color: var(--text-secondary);
+}
+
+.category-bar {
+  flex: 1;
+  height: 8px;
+  background: var(--bg-secondary);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.category-fill {
+  height: 100%;
+  background: linear-gradient(90deg, var(--color-primary), var(--color-accent));
+  transition: width 0.3s ease;
+}
+
+.category-percentage {
+  font-size: var(--font-size-xs);
+  font-weight: 500;
+  color: var(--color-primary);
+  min-width: 35px;
+  text-align: right;
+}
+
+.pattern-insights {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.insight-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--spacing-sm);
+  background: var(--bg-light);
+  border-radius: 6px;
+}
+
+.insight-label {
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+}
+
+.insight-value {
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+/* 거래내역 탭 상세 스타일링 */
+.transactions-tab-content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-lg);
+}
+
+.transaction-filters {
+  background: var(--bg-card);
+  border-radius: 12px;
+  padding: var(--spacing-lg);
+  box-shadow: var(--shadow-sm);
+}
+
+.filter-row {
+  display: flex;
+  gap: var(--spacing-md);
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.search-box {
+  flex: 1;
+  min-width: 250px;
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.search-box i {
+  position: absolute;
+  left: 12px;
+  color: var(--text-secondary);
+  z-index: 1;
+}
+
+.search-input {
+  width: 100%;
+  padding: 10px 12px 10px 36px;
+  border: 1px solid var(--border-light);
+  border-radius: 8px;
+  font-size: var(--font-size-sm);
+  background: var(--bg-light);
+}
+
+.search-input:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  background: white;
+}
+
+.filter-buttons {
+  display: flex;
+  gap: var(--spacing-sm);
+  flex-wrap: wrap;
+}
+
+.filter-select {
+  padding: 8px 12px;
+  border: 1px solid var(--border-light);
+  border-radius: 6px;
+  font-size: var(--font-size-sm);
+  background: var(--bg-light);
+  min-width: 120px;
+}
+
+.filter-select:focus {
+  outline: none;
+  border-color: var(--color-primary);
+}
+
+.transaction-stats {
+  background: var(--bg-card);
+  border-radius: 12px;
+  padding: var(--spacing-lg);
+  box-shadow: var(--shadow-sm);
+}
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: var(--spacing-md);
+}
+
+.stat-card {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: var(--spacing-md);
+  background: var(--bg-light);
+  border-radius: 8px;
+}
+
+.stat-info {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.stat-number {
+  font-size: var(--font-size-base);
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.stat-text {
+  font-size: var(--font-size-xs);
+  color: var(--text-secondary);
+}
+
+.sort-options {
+  margin: var(--spacing-md) 0;
+}
+
+.sort-buttons {
+  display: flex;
+  gap: var(--spacing-xs);
+}
+
+.sort-btn {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 12px;
+  border: 1px solid var(--border-light);
+  border-radius: 6px;
+  background: var(--bg-light);
+  color: var(--text-secondary);
+  font-size: var(--font-size-xs);
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.sort-btn:hover {
+  background: var(--bg-secondary);
+  border-color: var(--color-primary);
+}
+
+.sort-btn.active {
+  background: var(--color-primary);
+  color: white;
+  border-color: var(--color-primary);
+}
+
+.transaction-item.enhanced {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  padding: var(--spacing-md);
+  background: var(--bg-card);
+  border: 1px solid var(--border-light);
+  border-radius: 8px;
+  transition: all 0.2s ease;
+}
+
+.transaction-item.enhanced:hover {
+  border-color: var(--color-primary);
+  box-shadow: var(--shadow-sm);
+}
+
+.transaction-main {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.transaction-date i,
+.merchant-name i,
+.transaction-type i {
+  margin-right: 4px;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.transaction-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  align-items: flex-end;
+  margin-top: var(--spacing-xs);
+}
+
+.transaction-time {
+  font-size: var(--font-size-xs);
+  color: var(--text-secondary);
+}
+
+.transaction-status {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: var(--font-size-xs);
+  color: var(--color-success);
+}
+
+.transaction-amount-section {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 4px;
+}
+
+.amount-details {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 2px;
+}
+
+.payment-method {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: var(--font-size-xs);
+  color: var(--text-secondary);
+}
+
+.pagination {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: var(--spacing-md);
+  margin: var(--spacing-lg) 0;
+}
+
+.page-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border: 1px solid var(--border-light);
+  border-radius: 6px;
+  background: var(--bg-light);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.page-btn:hover:not(:disabled) {
+  background: var(--color-primary);
+  color: white;
+  border-color: var(--color-primary);
+}
+
+.page-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.page-info {
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.transaction-actions {
+  display: flex;
+  gap: var(--spacing-sm);
+  justify-content: center;
+  margin-top: var(--spacing-lg);
+}
+
+/* 카드 추천 섹션 스타일링 */
+.card-recommendation-section {
+  width: 100%;
 }
 
 /* 반응형 디자인 */
@@ -920,6 +2334,79 @@ onMounted(() => {
 
   .step-item {
     padding: var(--spacing-md);
+  }
+
+  /* 탭 버튼 모바일 스타일 */
+  .tab-buttons {
+    margin-bottom: var(--spacing-lg);
+  }
+
+  .tab-button {
+    padding: 10px 12px;
+    font-size: var(--font-size-sm);
+  }
+
+  .tab-button i {
+    font-size: 14px;
+  }
+
+  /* 카드 추천 탭 모바일 */
+  .quick-stats {
+    grid-template-columns: 1fr;
+  }
+
+  .info-cards {
+    grid-template-columns: 1fr;
+  }
+
+  /* 소비 통계 탭 모바일 */
+  .summary-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .analysis-grid {
+    grid-template-columns: 1fr;
+  }
+
+  /* 거래내역 탭 모바일 */
+  .filter-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .search-box {
+    min-width: auto;
+  }
+
+  .filter-buttons {
+    justify-content: stretch;
+  }
+
+  .filter-select {
+    flex: 1;
+  }
+
+  .stats-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .sort-buttons {
+    justify-content: center;
+    flex-wrap: wrap;
+  }
+
+  .transaction-item.enhanced {
+    flex-direction: column;
+    align-items: stretch;
+    gap: var(--spacing-sm);
+  }
+
+  .transaction-amount-section {
+    align-items: flex-start;
+  }
+
+  .transaction-actions {
+    flex-direction: column;
   }
 }
 </style>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -20,6 +20,9 @@ import PersonaSavingAllList from "@/pages/persona/PersonaSavingAllListPage.vue";
 
 import RecommendSavings from "@/pages/savings/recommendations/RecommendSavings.vue";
 import MyDataCardPage from "@/pages/mydata/MyDataCardPage.vue";
+
+import CardRecommendationPage from "@/pages/cards/CardRecommendationPage.vue";
+
 /* 결과 페이지 (동적 import) */
 const ResultPage = () => import("@/pages/persona/PersonaResultPage.vue");
 
@@ -81,11 +84,22 @@ const routes = [
     name: "RecommendSavings",
     component: RecommendSavings,
   },
-  
+
   {
     path: "/mydata/cards",
     name: "MyDataCards",
     component: MyDataCardPage,
+  },
+  {
+    path: "/cards/recommendations",
+    name: "CardRecommendations",
+    component: CardRecommendationPage,
+  },
+  {
+    path: "/cards/recommendations/:cardId",
+    name: "CardRecommendation",
+    component: CardRecommendationPage,
+    props: true,
   },
   {
     path: "/persona",


### PR DESCRIPTION
## 🔥 PR 제목
- [Feat] 보유 카드 거래내역 기반 카드 추천

---

## 📎 관련 이슈
- Closes #54 

---

## 🛠 작업 내용
카드 아래의 버튼을 통해 컴포넌트 교체로 카드 추천, 소비 통계, 거래 내역 등 컴포넌트 교체
<img width="574" height="442" alt="image" src="https://github.com/user-attachments/assets/4b2143ab-0d51-46d8-9fb1-18aef2e9b250" />

[카드 추천]
<img width="1270" height="657" alt="image" src="https://github.com/user-attachments/assets/a75f3431-8468-4fca-9903-adacf4cf0a88" />
카드의 혜택에 대한 로직은 추가 보완, 데이터 필터링이 더 필요합니다.

[소비 통계]
<img width="623" height="660" alt="image" src="https://github.com/user-attachments/assets/de5757c6-fb7a-4d2d-b67e-3b08ea380d1d" />

[거래 내역]
<img width="952" height="634" alt="image" src="https://github.com/user-attachments/assets/98cc6edf-f6cb-4798-b770-a032cd02a297" />