### PR TITLE
[Feat] 카드 필터링 검색에 즐겨찾기 및 비교함 추가

### DIFF
--- a/src/pages/persona/PersonaCardAllList.vue
+++ b/src/pages/persona/PersonaCardAllList.vue
@@ -186,20 +186,34 @@
         <div v-else class="search-results-grid">
           <div
             v-for="product in searchResults"
-            :key="product.id || product.cardId"
+            :key="product.id"
             class="product-card"
-            @click="selectProduct(product)"
           >
-            <div class="product-content">
-              <img
-                :src="
-                  product.imageUrl ||
-                  product.cardImageUrl ||
-                  getBankLogo('default')
-                "
-                :alt="product.name || product.cardName"
-                class="product-image"
+            <div class="card-favorite-button">
+              <FavoriteToggle
+                v-model="product.is_starred"
+                :productId="product.id"
+                productType="CARD"
               />
+            </div>
+            <div class="product-content" @click="selectProduct(product)">
+              <div class="card-left-section">
+                <img
+                  :src="
+                    product.imageUrl ||
+                    product.cardImageUrl ||
+                    getBankLogo('default')
+                  "
+                  :alt="product.name || product.cardName"
+                  class="product-image"
+                />
+                <div class="card-compare-button">
+                  <CompareButton
+                    :productId="product.id || product.cardId"
+                    productType="CARD"
+                  />
+                </div>
+              </div>
               <div class="product-info">
                 <h4>{{ product.name || product.cardName }}</h4>
                 <div>
@@ -251,6 +265,8 @@ import { Swiper, SwiperSlide } from 'swiper/vue';
 import 'swiper/css';
 import 'swiper/css/pagination';
 import { Pagination } from 'swiper/modules';
+import FavoriteToggle from '@/components/common/FavoriteToggle.vue';
+import CompareButton from '@/components/common/CompareButton.vue';
 const modules = [Pagination];
 
 const isMobile = ref(window.innerWidth <= 768);
@@ -625,6 +641,7 @@ onMounted(() => {
   align-items: center;
   justify-content: start;
   text-align: center;
+  min-height: 24rem;
 }
 .product-card:hover {
   transform: translateY(-0.3125rem);
@@ -705,5 +722,21 @@ onMounted(() => {
 }
 .swiper-pagination-bullet-active {
   opacity: 1;
+}
+.card-favorite-button {
+  width: 100%;
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+.card-left-section {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.card-compare-button {
+  margin-top: 0.5rem;
 }
 </style>

--- a/src/pages/persona/PersonaCardAllList.vue
+++ b/src/pages/persona/PersonaCardAllList.vue
@@ -191,7 +191,7 @@
           >
             <div class="card-favorite-button">
               <FavoriteToggle
-                v-model="product.is_starred"
+                v-model="product.isStarred"
                 :productId="product.id"
                 productType="CARD"
               />


### PR DESCRIPTION
## 🔥 PR 제목
- [Feat] 카드 필터링 검색에 즐겨찾기 및 비교함 추가

---

## 📎 관련 이슈
- Closes #104 

---

## 🛠 작업 내용
<img width="2880" height="1454" alt="image" src="https://github.com/user-attachments/assets/4c9ae89c-8847-4999-8ace-a872c4783da3" />

<br>

- 즐겨찾기랑 비교함 추가하고 연동 확인 완료


