### PR TITLE
[Fix] 페르소나 페이지 반응형 수정

### DIFF
--- a/src/pages/persona/PersonaCardAllList.vue
+++ b/src/pages/persona/PersonaCardAllList.vue
@@ -43,8 +43,8 @@
                 }}
               </div>
               <div>
-                <span class="label">연회비 정보:</span>
-                {{ card.annualFee || '정보 없음' }}
+                <span class="label">연회비:</span>
+                {{ card.annualFee.replace(/\[|\]/g, '') || '정보 없음' }}
               </div>
               <!-- 안전하게 조건 체크 -->
               <div
@@ -98,8 +98,8 @@
                 }}
               </div>
               <div>
-                <span class="label">연회비 정보:</span>
-                {{ card.annualFee || '정보 없음' }}
+                <span class="label">연회비:</span>
+                {{ card.annualFee.replace(/\[|\]/g, '') || '정보 없음' }}
               </div>
               <!-- 안전하게 조건 체크 -->
               <div
@@ -242,8 +242,8 @@
                   }}
                 </div>
                 <div>
-                  <span class="label">연회비 정보:</span>
-                  {{ product.annualFee || '정보 없음' }}
+                  <span class="label">연회비:</span>
+                  {{ product.annualFee.replace(/\[|\]/g, '') || '정보 없음' }}
                 </div>
 
                 <!-- ⭐ 혜택 태그 추가 -->

--- a/src/pages/persona/PersonaCardAllList.vue
+++ b/src/pages/persona/PersonaCardAllList.vue
@@ -691,6 +691,31 @@ onMounted(() => {
     width: 220px;
     height: 320px;
   }
+  .card-compare-button {
+    display: flex;
+    align-items: center;
+  }
+
+  /* LikeToggle 전체 크기 살짝 축소 */
+  .card-compare-button > *:first-child {
+    transform: scale(0.85);
+    transform-origin: left center;
+  }
+
+  /* LikeToggle 내부(하트+숫자) 간격/패딩 보정 */
+  .card-compare-button :deep(.like-chip) {
+    padding: 0.35rem 0.7rem; /* 칩 자체를 살짝 줄임 */
+    border-radius: 999px;
+    line-height: 1;
+  }
+  .card-compare-button :deep(.like-icon) {
+    margin-right: 0.3rem; /* 하트 ↔ 숫자 간격 */
+    width: 1rem; /* 아이콘이 img/svg면 적용됨 */
+    height: 1rem;
+  }
+  .card-compare-button :deep(.like-count) {
+    font-size: 0.95rem; /* 숫자 조금만 축소 */
+  }
 }
 </style>
 <style scoped>
@@ -793,7 +818,7 @@ onMounted(() => {
   display: flex;
   justify-content: flex-end;
   gap: 0.5rem;
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.2rem;
 }
 .card-left-section {
   display: flex;

--- a/src/pages/persona/PersonaCardAllList.vue
+++ b/src/pages/persona/PersonaCardAllList.vue
@@ -672,17 +672,42 @@ onMounted(() => {
     grid-template-columns: 1fr;
   }
   .benefit-grid {
-    display: flex;
-    overflow-x: auto;
-    padding: var(--spacing-sm);
-    gap: var(--spacing-md);
-    scroll-snap-type: x mandatory;
+    display: grid !important;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.75rem;
+    overflow: visible; /* 기존 overflow-x 제거 효과 */
+    scroll-snap-type: none; /* 스냅 제거 */
+    padding: 0 var(--spacing-sm);
   }
+
   .benefit-button {
-    flex: 0 0 auto;
-    scroll-snap-align: start;
-    min-width: 6rem;
+    width: 100%;
+    min-height: 4.8rem;
+    aspect-ratio: 1 / 1;
+    padding: 0.5rem;
+    border-radius: 12px;
+    /* 기존 flex 스크롤 흔적 무력화 */
+    flex: initial;
+    scroll-snap-align: unset;
   }
+
+  .benefit-button .emoji {
+    font-size: 1.6rem;
+    margin-bottom: 0.3rem;
+  }
+
+  /* 라벨: 2줄까지 깔끔히 보이게 */
+  .benefit-button span:last-child {
+    font-size: 0.92rem;
+    line-height: 1.25;
+    text-align: center;
+    display: -webkit-box;
+    -webkit-line-clamp: 2; /* 최대 2줄 */
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    word-break: keep-all;
+  }
+
   .carousel-card-list {
     justify-content: center;
     overflow-x: hidden;

--- a/src/pages/persona/PersonaDepositAllListPage.vue
+++ b/src/pages/persona/PersonaDepositAllListPage.vue
@@ -164,7 +164,7 @@
                   alt="은행 로고"
                   class="bank-logo-round"
                 />
-                <div class="card-compare-button" @click.stop>
+                <div class="deposit-compare-button" @click.stop>
                   <LikeToggle
                     :productId="product.id"
                     productType="deposit-products"
@@ -1022,7 +1022,7 @@ const selectProduct = (product) => {
     gap: var(--spacing-lg);
   }
   .bank-logo-container {
-    width: 5.6rem;
+    width: 6rem;
     height: 2rem;
   }
   .bank-logo-round {
@@ -1063,6 +1063,12 @@ const selectProduct = (product) => {
     flex-direction: column;
     align-items: center;
     margin-bottom: var(--spacing-lg);
+  }
+
+  .deposit-compare-button > *:first-child {
+    transform: scale(0.7); /* 전체 크기 80%로 축소 */
+    transform-origin: center; /* 축소 기준 중앙 */
+    margin-right: -1rem;
   }
 }
 
@@ -1179,7 +1185,17 @@ body {
   margin-bottom: 0.5rem;
 }
 
-.card-compare-button {
+.deposit-compare-button {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
   margin-top: 0.5rem;
+  flex-wrap: nowrap;
+  gap: 0.4rem;
+}
+
+.deposit-compare-button > * {
+  white-space: nowrap;
 }
 </style>

--- a/src/pages/persona/PersonaDepositAllListPage.vue
+++ b/src/pages/persona/PersonaDepositAllListPage.vue
@@ -940,6 +940,7 @@ const selectProduct = (product) => {
   font-weight: 800;
   color: var(--text-primary);
   margin-bottom: 0.2rem;
+  text-align: left;
 }
 .rate-line {
   font-size: var(--font-size-sm);

--- a/src/pages/persona/PersonaDepositAllListPage.vue
+++ b/src/pages/persona/PersonaDepositAllListPage.vue
@@ -25,11 +25,11 @@
             <div class="bank-name-bold">{{ deposit.bankName }}</div>
             <div class="carousel-deposit-rates-inline">
               <span>
-                <strong>최고 금리:</strong>
+                <strong>최고 금리: </strong>
                 {{ deposit.maxRate }}
               </span>
               <span>
-                <strong>최저 금리:</strong>
+                <strong>최저 금리: </strong>
                 {{ deposit.baseRate }}
               </span>
             </div>
@@ -60,11 +60,11 @@
             <div class="bank-name-bold">{{ deposit.bankName }}</div>
             <div class="carousel-deposit-rates-inline">
               <span>
-                <strong>최고 금리:</strong>
+                <strong>최고 금리: </strong>
                 {{ deposit.maxRate }}
               </span>
               <span>
-                <strong>최저 금리:</strong>
+                <strong>최저 금리: </strong>
                 {{ deposit.baseRate }}
               </span>
             </div>
@@ -188,13 +188,13 @@
                 <div class="product-name-bold">{{ product.name }}</div>
                 <div class="bank-name-bold">{{ product.bank }}</div>
                 <div class="rate-line">
-                  <span class="label-bold">최고 금리 :</span>
+                  <span class="label-bold">최고 금리 : </span>
                   <span class="highlight-rate">{{
                     getRateWithTerm(product, 'max')
                   }}</span>
                 </div>
                 <div class="rate-line">
-                  <span class="label-bold">최저 금리 :</span>
+                  <span class="label-bold">최저 금리 : </span>
                   <span>{{ getRateWithTerm(product, 'base') }}</span>
                 </div>
                 <div class="rate-line">

--- a/src/pages/persona/PersonaDepositAllListPage.vue
+++ b/src/pages/persona/PersonaDepositAllListPage.vue
@@ -463,6 +463,8 @@ const carouselDeposits = computed(() => {
 
 onMounted(async () => {
   let personaCode = null;
+  loading.value = true;
+
   const token = localStorage.getItem('accessToken');
   const authConfig = token
     ? { headers: { Authorization: `Bearer ${token}` } }
@@ -505,12 +507,6 @@ onMounted(async () => {
   }
 
   try {
-    // 전체 적금 리스트
-    const allRes = await api.post('/deposit/search', {
-      korCoNm: '',
-      maxLimit: null,
-      authConfig,
-    });
     const fullList = listRes.data.map((item) => ({
       id: item.depositProductId,
       name: item.finPrdtNm,
@@ -528,6 +524,8 @@ onMounted(async () => {
     allProducts.value = fullList;
   } catch (err) {
     console.error('❌ 전체 상품 불러오기 실패:', err);
+  } finally {
+    loading.value = false;
   }
 });
 

--- a/src/pages/persona/PersonaDepositAllListPage.vue
+++ b/src/pages/persona/PersonaDepositAllListPage.vue
@@ -40,7 +40,7 @@
         <Swiper
           v-else
           :modules="modules"
-          :slides-per-view="1.2"
+          :slides-per-view="1"
           :space-between="16"
           :pagination="{ clickable: true }"
           class="carousel-swiper"

--- a/src/pages/persona/PersonaSavingAllListPage.vue
+++ b/src/pages/persona/PersonaSavingAllListPage.vue
@@ -1067,7 +1067,7 @@ const getMinAmountWithTerm = (product) => {
   }
 
   .bank-logo-container {
-    width: 5.6rem;
+    width: 6rem;
     height: 4rem;
     flex-shrink: 0;
     display: flex;
@@ -1131,6 +1131,12 @@ const getMinAmountWithTerm = (product) => {
 
   .term-dropdown-wrapper {
     display: flex;
+  }
+
+  .saving-compare-button > *:first-child {
+    transform: scale(0.7); /* 전체 크기 80%로 축소 */
+    transform-origin: center; /* 축소 기준 중앙 */
+    margin-right: -1rem;
   }
 }
 
@@ -1218,7 +1224,17 @@ text-align: center;
   margin-bottom: 0.5rem;
 }
 .saving-compare-button {
+  display: flex; /* 가로 배치 */
+  flex-direction: row;
+  align-items: center; /* 수직 중앙 */
+  justify-content: center; /* 수평 중앙 */
   margin-top: 0.5rem;
+  flex-wrap: nowrap;
+  gap: 0.4rem;
+}
+
+.saving-compare-button > * {
+  white-space: nowrap; /* 버튼 안 텍스트 줄바꿈 방지 */
 }
 
 /* 무한 스크롤 로딩 스피너 */

--- a/src/pages/persona/PersonaSavingAllListPage.vue
+++ b/src/pages/persona/PersonaSavingAllListPage.vue
@@ -225,13 +225,13 @@
                 <div class="bank-name-bold">{{ product.bank }}</div>
 
                 <div class="rate-line">
-                  <span class="label-bold">최고 금리 :</span>
+                  <span class="label-bold">최고 금리 : </span>
                   <span class="highlight-rate">{{
                     getRateWithTerm(product, 'max')
                   }}</span>
                 </div>
                 <div class="rate-line">
-                  <span class="label-bold">최저 금리 :</span>
+                  <span class="label-bold">최저 금리 : </span>
                   <span>{{ getRateWithTerm(product, 'base') }}</span>
                 </div>
                 <div class="rate-line no-wrap">
@@ -997,6 +997,7 @@ const getMinAmountWithTerm = (product) => {
   font-weight: 800;
   color: var(--text-primary);
   /* margin-bottom: 0.2rem; */
+  text-align: left;
 }
 
 .rate-line {

--- a/src/pages/persona/PersonaSavingAllListPage.vue
+++ b/src/pages/persona/PersonaSavingAllListPage.vue
@@ -43,7 +43,7 @@
         <Swiper
           v-else
           :modules="modules"
-          :slides-per-view="1.2"
+          :slides-per-view="1"
           :space-between="16"
           :pagination="{ clickable: true }"
           class="carousel-swiper"

--- a/src/pages/persona/PersonaSavingAllListPage.vue
+++ b/src/pages/persona/PersonaSavingAllListPage.vue
@@ -871,8 +871,8 @@ const getMinAmountWithTerm = (product) => {
 }
 
 .bank-logo-option {
-  width: 140px;
-  height: 140px;
+  width: 120px;
+  height: 120px;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -1077,6 +1077,11 @@ const getMinAmountWithTerm = (product) => {
   .bank-logo-round {
     width: 5.6rem;
     height: 5.6rem;
+  }
+
+  .bank-logo-img {
+    width: 7rem;
+    height: 7rem;
   }
 }
 </style>


### PR DESCRIPTION
## 🔥 PR 제목
- [Fix] 페르소나 페이지 반응형 수정

---

## 📎 관련 이슈
- Closes #128 
---

## 🛠 작업 내용
- 예금 검색 결과 뜨지 않는 에러 해결
- 모바일 사이즈에서 페르소나 예적금 슬라이드 왼쪽으로 치우쳐져 있던 부분 수정
<img width="368" height="654" alt="image" src="https://github.com/user-attachments/assets/173c379d-d4da-41a5-861c-8c92db8aecc1" />

<br><br>

- 페르소나 예적금 좋아요 가로배치 되도록 수정
<img width="368" height="654" alt="image" src="https://github.com/user-attachments/assets/3a63150e-9cae-4673-bc65-07acffc0784e" />

<br><br>

- 카드 필터링 혜택 가로스크롤 제거
<img width="368" height="654" alt="image" src="https://github.com/user-attachments/assets/69ca4f01-a80a-45bf-b257-edb0e0d59a68" />

<br><br>

- 이미지/텍스트 크기나 배치 수정


