### PR TITLE
[Feat] 마이페이지에 상위 퍼센트 배지 구현

### DIFF
--- a/src/api/user.js
+++ b/src/api/user.js
@@ -1,4 +1,4 @@
-import api from "@/api";
+import api from '@/api';
 
 const BASE_URL = `user`;
 
@@ -13,6 +13,11 @@ export default {
     const { data } = await api.get(`${BASE_URL}/mypage`);
     return data;
   },
+  // 상위 퍼센트 조회
+  async getTopPercent() {
+    const { data } = await api.get(`${BASE_URL}/mypage/top-percent`);
+    return data;
+  },
   // 회원 정보 수정
   async updateUserInfo(updateDto) {
     const { data } = await api.patch(`${BASE_URL}/update`, updateDto);
@@ -20,7 +25,10 @@ export default {
   },
   // 비밀번호 수정
   async updatePassword(passwordDto) {
-    const { data } = await api.patch(`${BASE_URL}/update/password`, passwordDto);
+    const { data } = await api.patch(
+      `${BASE_URL}/update/password`,
+      passwordDto
+    );
     return data;
   },
 };


### PR DESCRIPTION
## 🔥 PR 제목
- [Feat] 마이페이지에 상위 퍼센트 배지 구현

---

## 📎 관련 이슈
- Closes #145 

---

## 🛠 작업 내용
- 퀴즈로 적립된 누적 경험치를 기준으로 사용자가 전체 유저 중 상위 몇 %인지 마이페이지에 노출

- 상위 몇 퍼센트인지에 따라 다른 색상의 배지로 매핑되도록 함
<img width="2048" height="586" alt="image" src="https://github.com/user-attachments/assets/9709f84d-07bb-46e7-a907-8b153345aa11" />

> **topPercent ≤ 1**

<br>

<img width="2048" height="586" alt="image" src="https://github.com/user-attachments/assets/c10ff356-2055-4b2a-baf0-ad5658abc37f" />

> **topPercent ≤ 10**

<br>

<img width="2048" height="586" alt="image" src="https://github.com/user-attachments/assets/58f0657d-a9b3-48f0-9a58-389d83daa6f6" />

> **그 외**

<br>

<img width="2048" height="586" alt="image" src="https://github.com/user-attachments/assets/75912fac-8db7-4940-bb70-3ee6667503ed" />

> **topPercent ≥ 90**

<br>


